### PR TITLE
fix fluid tally in ME networks

### DIFF
--- a/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2Helper.kt
+++ b/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2Helper.kt
@@ -36,28 +36,31 @@ object AE2Helper {
         return base
     }
 
-    fun keyCounterToLua(counter: KeyCounter, predicate: Predicate<AEKey> = ALWAYS, displayType: Boolean = false): MutableList<Map<String, Any>> {
-        val items = mutableListOf<Map<String, Any>>()
-        counter.forEach {
-            val aeKey = it.key
-            if (predicate.test(aeKey)) {
-                if (aeKey is AEItemKey) {
-                    val data = LuaRepresentation.forItemStack(aeKey.toStack(it.longValue.toInt()))
-                    data.remove("maxStackSize")
-                    if (displayType)
-                        data["type"] = "item"
-                    items.add(data)
-                } else if (aeKey is AEFluidKey) {
-                    val data = mutableMapOf(
-                        "name" to Registry.FLUID.getKey(aeKey.fluid).toString(),
-                        "amount" to it.longValue / FluidStoragePlugin.FORGE_COMPACT_DEVIDER,
-                    )
-                    if (displayType)
-                        data["type"] = "fluid"
+    fun keyCounterToLua(counter: KeyCounter, predicate: Predicate<AEKey> = ALWAYS, displayType: Boolean = false): List<Map<String, Any>> {
+        return counter
+            .mapNotNull { entry ->
+                val aeKey = entry.key
+                when {
+                    !predicate.test(aeKey) -> null
+                    aeKey is AEItemKey -> {
+                        val data = LuaRepresentation.forItemStack(aeKey.toStack(entry.longValue.toInt()))
+                        data.remove("maxStackSize")
+                        if (displayType)
+                            data["type"] = "item"
+                        data
+                    }
+                    aeKey is AEFluidKey -> {
+                        val data = mutableMapOf(
+                            "name" to Registry.FLUID.getKey(aeKey.fluid).toString(),
+                            "amount" to entry.longValue / FluidStoragePlugin.FORGE_COMPACT_DEVIDER,
+                        )
+                        if (displayType)
+                            data["type"] = "fluid"
+                        data
+                    }
+                    else -> null
                 }
             }
-        }
-        return items
     }
 
     fun buildKey(mode: String, id_key: String): AEKey {

--- a/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/MENetworkBlockPlugin.kt
+++ b/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/MENetworkBlockPlugin.kt
@@ -67,7 +67,6 @@ class MENetworkBlockPlugin(private val level: Level, private val entity: AENetwo
     @LuaFunction(mainThread = true)
     fun items(): MethodResult {
         val inventory = entity.mainNode.grid?.storageService?.inventory ?: throw LuaException("Not correctly configured AE2 Network")
-        val items = mutableListOf<Map<String, Any>>()
         return MethodResult.of(keyCounterToLua(inventory.availableStacks, {it is AEItemKey}))
     }
 


### PR DESCRIPTION
I've tested your mod today (mainly for the integration with AE2) and found out that the listing of fluids (`tanks` Lua function) in an ME network always returns an empty table. I prepared a fix and tested it in a simple scenario. It seems to work. What caused problems in your implementation is a missing `items.add(data)`. For that reason I've refactored it to use a `map` so that similar mistake is not possible in the future.