### PR TITLE
fix fluid tally in ME networks and update peripheralium

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ modVersion = 0.2.1
 mavenGroup = siredvin.site
 archivesBaseName = peripheralworks
 # Dependencies
-peripheraliumVersion = 0.4.3
+peripheraliumVersion = 0.4.15
 # Kotlin
 systemProp.kotlinVersion = 1.7.20
 fabricKotlinVersion = 1.8.5+kotlin.1.7.20

--- a/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2Helper.kt
+++ b/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2Helper.kt
@@ -36,28 +36,31 @@ object AE2Helper {
         return base
     }
 
-    fun keyCounterToLua(counter: KeyCounter, predicate: Predicate<AEKey> = ALWAYS, displayType: Boolean = false): MutableList<Map<String, Any>> {
-        val items = mutableListOf<Map<String, Any>>()
-        counter.forEach {
-            val aeKey = it.key
-            if (predicate.test(aeKey)) {
-                if (aeKey is AEItemKey) {
-                    val data = LuaRepresentation.forItemStack(aeKey.toStack(it.longValue.toInt()))
-                    data.remove("maxStackSize")
-                    if (displayType)
-                        data["type"] = "item"
-                    items.add(data)
-                } else if (aeKey is AEFluidKey) {
-                    val data = mutableMapOf(
-                        "name" to Registry.FLUID.getKey(aeKey.fluid).toString(),
-                        "amount" to it.longValue / FluidStoragePlugin.FORGE_COMPACT_DEVIDER,
-                    )
-                    if (displayType)
-                        data["type"] = "fluid"
+    fun keyCounterToLua(counter: KeyCounter, predicate: Predicate<AEKey> = ALWAYS, displayType: Boolean = false): List<Map<String, Any>> {
+        return counter
+            .mapNotNull { entry ->
+                val aeKey = entry.key
+                when {
+                    !predicate.test(aeKey) -> null
+                    aeKey is AEItemKey -> {
+                        val data = LuaRepresentation.forItemStack(aeKey.toStack(entry.longValue.toInt()))
+                        data.remove("maxStackSize")
+                        if (displayType)
+                            data["type"] = "item"
+                        data
+                    }
+                    aeKey is AEFluidKey -> {
+                        val data = mutableMapOf(
+                            "name" to Registry.FLUID.getKey(aeKey.fluid).toString(),
+                            "amount" to entry.longValue / FluidStoragePlugin.FORGE_COMPACT_DEVIDER,
+                        )
+                        if (displayType)
+                            data["type"] = "fluid"
+                        data
+                    }
+                    else -> null
                 }
             }
-        }
-        return items
     }
 
     fun buildKey(mode: String, id_key: String): AEKey {

--- a/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/MENetworkBlockPlugin.kt
+++ b/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/MENetworkBlockPlugin.kt
@@ -24,7 +24,6 @@ import net.minecraft.world.item.Items
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.material.Fluids
 import site.siredvin.peripheralium.api.peripheral.IPeripheralPlugin
-import site.siredvin.peripheralium.api.peripheral.IPluggablePeripheral
 import site.siredvin.peripheralium.common.ExtractorProxy
 import site.siredvin.peripheralium.common.configuration.PeripheraliumConfig
 import site.siredvin.peripheralium.extra.plugins.FluidStoragePlugin
@@ -67,7 +66,6 @@ class MENetworkBlockPlugin(private val level: Level, private val entity: AENetwo
     @LuaFunction(mainThread = true)
     fun items(): MethodResult {
         val inventory = entity.mainNode.grid?.storageService?.inventory ?: throw LuaException("Not correctly configured AE2 Network")
-        val items = mutableListOf<Map<String, Any>>()
         return MethodResult.of(keyCounterToLua(inventory.availableStacks, {it is AEItemKey}))
     }
 


### PR DESCRIPTION
I've tested your mod today (mainly for the integration with AE2) and found out that the listing of fluids (`tanks` Lua function) in an ME network always returns an empty table. I prepared a fix and tested it in a simple scenario. It seems to work. What caused problems in your implementation is a missing `items.add(data)`. For that reason I've refactored it to use a `map` so that similar mistake is not possible in the future.

I had to update peripheralium as well because when I published it locally from the 1.18 branch then it was not the right version.