### PR TITLE
Fix crafting recipes

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
@@ -58,7 +58,10 @@ class RecipeRegistryPeripheral(
 
         @Suppress("UNCHECKED_CAST")
         val type = XplatRegistries.RECIPE_TYPES.tryGet(recipeTypeID) as? RecipeType<Recipe<Container>> ?: return MethodResult.of(false, "Cannot find recipe type $recipeTypeID")
-        return MethodResult.of(level!!.recipeManager.getAllRecipesFor(type).filter { it.id == recipeID }.map(RecipeRegistryToolkit::serializeRecipe).toList())
+        return MethodResult.of(level!!.recipeManager.getAllRecipesFor(type)
+            .filter { it.id == recipeID }
+            .map { RecipeRegistryToolkit.serializeRecipe(it, level!!.registryAccess()) }
+            .toList())
     }
 
     @LuaFunction
@@ -72,9 +75,9 @@ class RecipeRegistryPeripheral(
             recipeTypes.flatMap {
                 @Suppress("UNCHECKED_CAST")
                 level!!.recipeManager.getAllRecipesFor(it as RecipeType<Recipe<Container>>).stream().filter { recipe ->
-                    recipe.getResultItem(RegistryAccess.EMPTY).`is`(targetItem)
+                    recipe.getResultItem(level!!.registryAccess()).`is`(targetItem)
                 }.toList()
-            },
+            }.map { RecipeRegistryToolkit.serializeRecipe(it, level!!.registryAccess()) },
         )
     }
 

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
@@ -26,6 +26,8 @@ class RecipeRegistryPeripheral(
         const val TYPE = "recipe_registry"
     }
 
+    val air = XplatRegistries.ITEMS.get(ResourceLocation("minecraft", "air"))
+
     override val isEnabled: Boolean
         get() = PeripheralWorksConfig.enableRecipeRegistry
 
@@ -69,7 +71,14 @@ class RecipeRegistryPeripheral(
     fun getRecipesFor(arguments: IArguments): MethodResult {
         val itemID: ResourceLocation = arguments.getResourceLocation(0)
         val types = arguments[1]
-        val targetItem = XplatRegistries.ITEMS.tryGet(itemID) ?: throw LuaException(String.format("Cannot find item with id %s", itemID))
+        val targetItem = XplatRegistries.ITEMS.tryGet(itemID)
+
+        if (targetItem == null || targetItem == air) {
+            // Item registry may return AIR when the item is not found, and I hope no
+            // one ever needs minecraft:air to be craftable...
+            throw LuaException(String.format("Cannot find item with id %s", itemID))
+        }
+
         val recipeTypes = RecipeRegistryToolkit.collectRecipeTypes(types)
         return MethodResult.of(
             recipeTypes.flatMap {

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/RecipeRegistryPeripheral.kt
@@ -4,7 +4,6 @@ import dan200.computercraft.api.lua.IArguments
 import dan200.computercraft.api.lua.LuaException
 import dan200.computercraft.api.lua.LuaFunction
 import dan200.computercraft.api.lua.MethodResult
-import net.minecraft.core.RegistryAccess
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.Container
 import net.minecraft.world.item.crafting.Recipe
@@ -60,10 +59,12 @@ class RecipeRegistryPeripheral(
 
         @Suppress("UNCHECKED_CAST")
         val type = XplatRegistries.RECIPE_TYPES.tryGet(recipeTypeID) as? RecipeType<Recipe<Container>> ?: return MethodResult.of(false, "Cannot find recipe type $recipeTypeID")
-        return MethodResult.of(level!!.recipeManager.getAllRecipesFor(type)
-            .filter { it.id == recipeID }
-            .map { RecipeRegistryToolkit.serializeRecipe(it, level!!.registryAccess()) }
-            .toList())
+        return MethodResult.of(
+            level!!.recipeManager.getAllRecipesFor(type)
+                .filter { it.id == recipeID }
+                .map { RecipeRegistryToolkit.serializeRecipe(it, level!!.registryAccess()) }
+                .toList(),
+        )
     }
 
     @LuaFunction

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/DefaultRecipeTransformer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/DefaultRecipeTransformer.kt
@@ -5,11 +5,11 @@ import net.minecraft.world.Container
 import net.minecraft.world.item.crafting.Recipe
 
 object DefaultRecipeTransformer : RecipeTransformer<Container, Recipe<Container>>() {
-    override fun getInputs(recipe: Recipe<Container>): List<*> {
+    override fun getInputs(recipe: Recipe<Container>, registryAccess: RegistryAccess): List<*> {
         return recipe.ingredients
     }
 
-    override fun getOutputs(recipe: Recipe<Container>): List<*> {
-        return listOf(recipe.getResultItem(RegistryAccess.EMPTY))
+    override fun getOutputs(recipe: Recipe<Container>, registryAccess: RegistryAccess): List<*> {
+        return listOf(recipe.getResultItem(registryAccess))
     }
 }

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeRegistryToolkit.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeRegistryToolkit.kt
@@ -14,18 +14,21 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.crafting.Ingredient
 import net.minecraft.world.item.crafting.Recipe
 import net.minecraft.world.item.crafting.RecipeType
+import net.minecraft.world.item.crafting.ShapedRecipe
 import net.minecraft.world.level.Level
 import net.minecraft.world.level.material.Fluid
 import site.siredvin.peripheralium.util.representation.LuaRepresentation
 import site.siredvin.peripheralium.xplat.PeripheraliumPlatform
 import site.siredvin.peripheralium.xplat.XplatRegistries
+import site.siredvin.peripheralworks.subsystem.recipe.integration.ShapedCraftingRecipeTransformer
 import java.util.*
 import java.util.stream.Collectors
 import kotlin.collections.HashMap
 
 object RecipeRegistryToolkit {
     private val GSON = Gson()
-    val SERIALIZATION_NULL = Any()
+    val SERIALIZATION_SKIP = Any()
+    val SERIALIZATION_EMPTY_SLOT = mapOf("type" to "empty")
 
     private val RECIPE_SERIALIZERS: MutableMap<Class<out Recipe<*>>, RecipeTransformer<*, Recipe<*>>> = mutableMapOf()
     private val SERIALIZERS: MutableMap<Class<*>, java.util.function.Function<Any, Any?>> = mutableMapOf()
@@ -50,7 +53,7 @@ object RecipeRegistryToolkit {
     init {
         registerSerializer(Ingredient::class.java) {
             if (it.isEmpty) {
-                return@registerSerializer SERIALIZATION_NULL
+                return@registerSerializer SERIALIZATION_EMPTY_SLOT
             }
             try {
                 return@registerSerializer GSON.fromJson(it.toJson(), HashMap::class.java)
@@ -64,7 +67,7 @@ object RecipeRegistryToolkit {
             return@registerSerializer null
         }
         registerSerializer(ItemStack::class.java) {
-            if (it.isEmpty) return@registerSerializer SERIALIZATION_NULL
+            if (it.isEmpty) return@registerSerializer SERIALIZATION_EMPTY_SLOT
             return@registerSerializer LuaRepresentation.forItemStack(it)
         }
         registerSerializer(Item::class.java, LuaRepresentation::forItem)
@@ -76,6 +79,8 @@ object RecipeRegistryToolkit {
             )
         }
         registerSerializer(Tag::class.java, PeripheraliumPlatform::nbtToLua)
+
+        registerRecipeSerializer(ShapedRecipe::class.java, ShapedCraftingRecipeTransformer)
     }
 
     fun <V : Container, T : Recipe<V>> registerRecipeSerializer(recipeClass: Class<T>, transformer: RecipeTransformer<V, T>) {

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeRegistryToolkit.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeRegistryToolkit.kt
@@ -127,13 +127,13 @@ object RecipeRegistryToolkit {
         return obj
     }
 
-    fun serializeRecipe(recipe: Recipe<*>): Map<String, Any> {
+    fun serializeRecipe(recipe: Recipe<*>, registryAccess: RegistryAccess): Map<String, Any> {
         for (recipeClass in RECIPE_SERIALIZERS.keys) {
             @Suppress("UNCHECKED_CAST")
-            if (recipeClass.isInstance(recipe)) return RECIPE_SERIALIZERS[recipeClass]!!.transform(recipe as Recipe<Container>)
+            if (recipeClass.isInstance(recipe)) return RECIPE_SERIALIZERS[recipeClass]!!.transform(recipe as Recipe<Container>, registryAccess)
         }
         @Suppress("UNCHECKED_CAST")
-        return DefaultRecipeTransformer.transform(recipe as Recipe<Container>)
+        return DefaultRecipeTransformer.transform(recipe as Recipe<Container>, registryAccess)
     }
 
     @Throws(LuaException::class)

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeTransformer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeTransformer.kt
@@ -1,5 +1,6 @@
 package site.siredvin.peripheralworks.subsystem.recipe
 
+import net.minecraft.core.RegistryAccess
 import net.minecraft.world.Container
 import net.minecraft.world.item.crafting.Recipe
 import java.util.*
@@ -9,9 +10,9 @@ import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
 abstract class RecipeTransformer<V : Container, T : Recipe<V>> {
-    abstract fun getInputs(recipe: T): List<*>
+    abstract fun getInputs(recipe: T, registryAccess: RegistryAccess): List<*>
 
-    abstract fun getOutputs(recipe: T): List<*>
+    abstract fun getOutputs(recipe: T, registryAccess: RegistryAccess): List<*>
 
     fun getExtraData(@Suppress("UNUSED_PARAMETER") recipe: T): MutableMap<String, Any>? {
         return null
@@ -23,12 +24,12 @@ abstract class RecipeTransformer<V : Container, T : Recipe<V>> {
         }.collect(Collectors.toList<Any>())
     }
 
-    fun transform(recipe: T): Map<String, Any> {
+    fun transform(recipe: T, registryAccess: RegistryAccess): Map<String, Any> {
         val recipeData: MutableMap<String, Any> = HashMap()
         recipeData["id"] = recipe.id.toString()
         recipeData["type"] = recipe.type.toString()
-        recipeData["output"] = serializeIngredients(getOutputs(recipe))
-        recipeData["input"] = serializeIngredients(getInputs(recipe))
+        recipeData["output"] = serializeIngredients(getOutputs(recipe, registryAccess))
+        recipeData["input"] = serializeIngredients(getInputs(recipe, registryAccess))
         val extraData = getExtraData(recipe)
         if (extraData != null) {
             // extra cleanup

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeTransformer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/RecipeTransformer.kt
@@ -3,24 +3,34 @@ package site.siredvin.peripheralworks.subsystem.recipe
 import net.minecraft.core.RegistryAccess
 import net.minecraft.world.Container
 import net.minecraft.world.item.crafting.Recipe
-import java.util.*
 import java.util.function.Consumer
 import java.util.stream.Collectors
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
 abstract class RecipeTransformer<V : Container, T : Recipe<V>> {
-    abstract fun getInputs(recipe: T, registryAccess: RegistryAccess): List<*>
+    open fun getInputs(recipe: T, registryAccess: RegistryAccess): List<*> {
+        return recipe.ingredients
+    }
 
-    abstract fun getOutputs(recipe: T, registryAccess: RegistryAccess): List<*>
+    open fun getOutputs(recipe: T, registryAccess: RegistryAccess): List<*> {
+        return listOf(recipe.getResultItem(registryAccess))
+    }
 
-    fun getExtraData(@Suppress("UNUSED_PARAMETER") recipe: T): MutableMap<String, Any>? {
+    open fun getExtraData(@Suppress("UNUSED_PARAMETER") recipe: T): MutableMap<String, Any>? {
         return null
     }
 
     protected fun serializeIngredients(originalData: List<*>): List<Any> {
-        return originalData.stream().filter(Objects::nonNull).map(RecipeRegistryToolkit::serialize).filter {
-            it !== RecipeRegistryToolkit.SERIALIZATION_NULL
+        return originalData.stream().map {
+            // null in the ingredient lists may be important!
+            //
+            // For example, shaped minecraft crafting recipes contain null's
+            // to indicate an empty slot. In order to retain the recipe shape,
+            // the null's need to be preserved!
+            it ?: RecipeRegistryToolkit.SERIALIZATION_EMPTY_SLOT
+        }.map(RecipeRegistryToolkit::serialize).filter {
+            it !== RecipeRegistryToolkit.SERIALIZATION_SKIP
         }.collect(Collectors.toList<Any>())
     }
 
@@ -35,7 +45,7 @@ abstract class RecipeTransformer<V : Container, T : Recipe<V>> {
             // extra cleanup
             val cleanupList: MutableList<String> = ArrayList()
             for (key in extraData.keys) {
-                if (extraData[key] === RecipeRegistryToolkit.SERIALIZATION_NULL) cleanupList.add(key)
+                if (extraData[key] === RecipeRegistryToolkit.SERIALIZATION_SKIP) cleanupList.add(key)
             }
             cleanupList.forEach(Consumer { o: String -> extraData.remove(o) })
             recipeData["extra"] = extraData

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/integration/ShapedCraftingRecipeTransformer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/integration/ShapedCraftingRecipeTransformer.kt
@@ -8,7 +8,7 @@ object ShapedCraftingRecipeTransformer : RecipeTransformer<CraftingContainer, Sh
     override fun getExtraData(recipe: ShapedRecipe): MutableMap<String, Any>? {
         return mutableMapOf(
             "width" to recipe.width,
-            "height" to recipe.height
+            "height" to recipe.height,
         )
     }
 }

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/integration/ShapedCraftingRecipeTransformer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/subsystem/recipe/integration/ShapedCraftingRecipeTransformer.kt
@@ -1,0 +1,14 @@
+package site.siredvin.peripheralworks.subsystem.recipe.integration
+
+import net.minecraft.world.inventory.CraftingContainer
+import net.minecraft.world.item.crafting.ShapedRecipe
+import site.siredvin.peripheralworks.subsystem.recipe.RecipeTransformer
+
+object ShapedCraftingRecipeTransformer : RecipeTransformer<CraftingContainer, ShapedRecipe>() {
+    override fun getExtraData(recipe: ShapedRecipe): MutableMap<String, Any>? {
+        return mutableMapOf(
+            "width" to recipe.width,
+            "height" to recipe.height
+        )
+    }
+}


### PR DESCRIPTION
The crafting recipe API has been mostly broken (see https://github.com/SirEdvin/UnlimitedPeripheralWorks/issues/34). This should make it work (and also make shaped recipes useful by not erasing information)