### PR TITLE
Add getPositionRemote, addPeripheral APIs and fix direction handling after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.18] - 2026-06-12
+
+### Added
+
+- `getPositionRemote(name)` API for peripheral proxies, returning the connected peripheral's world position and direction
+- `addPeripheral(position, direction)` API for connecting a peripheral without the configurator
+
+### Fixed
+
+- Peripheral proxies now use the saved peripheral direction when reconnecting after loading
 
 ## [1.7.17] - 2026-02-20
 

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/PeripheralProxyBlockEntity.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/PeripheralProxyBlockEntity.kt
@@ -209,7 +209,7 @@ class PeripheralProxyBlockEntity(blockPos: BlockPos, blockState: BlockState) :
 
     fun connectBlockPos(level: Level, record: RemotePeripheralRecord) {
         if (level is ServerLevel) {
-            val targetPeripheral = ComputerPlatformToolkit.get().getPeripheral(level, record.targetBlock, Direction.NORTH)
+            val targetPeripheral = ComputerPlatformToolkit.get().getPeripheral(level, record.targetBlock, record.direction)
             if (targetPeripheral == null) {
                 PeripheralWorksCore.logger.debug(
                     "Postpone {} for peripheral proxing, it doesn't contains any peripheral for now",

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/PeripheralProxyPeripheral.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/peripherals/PeripheralProxyPeripheral.kt
@@ -1,9 +1,16 @@
 package site.siredvin.peripheralworks.computercraft.peripherals
 
+import dan200.computercraft.api.lua.LuaFunction
+import dan200.computercraft.api.lua.MethodResult
+import net.minecraft.core.Direction
+import net.minecraft.server.level.ServerLevel
 import site.siredvin.peripheralworks.common.blockentity.PeripheralProxyBlockEntity
 import site.siredvin.peripheralworks.common.configuration.PeripheralWorksConfig
 import site.siredvin.peripheralworks.computercraft.modem.PeripheralHubPeripheral
+import site.siredvin.peripheralworks.tags.BlockTags
 import site.siredvin.tweakium.modules.peripheral.owner.BlockEntityPeripheralOwner
+import site.siredvin.tweakium.modules.peripheral.representation.LuaInterpretation
+import site.siredvin.tweakium.modules.platform.ComputerPlatformToolkit
 
 class PeripheralProxyPeripheral(private val blockEntity: PeripheralProxyBlockEntity) : PeripheralHubPeripheral<BlockEntityPeripheralOwner<PeripheralProxyBlockEntity>>(TYPE, BlockEntityPeripheralOwner(blockEntity)) {
 
@@ -15,6 +22,38 @@ class PeripheralProxyPeripheral(private val blockEntity: PeripheralProxyBlockEnt
         get() = PeripheralWorksConfig.enablePeripheralProxy
 
     override fun getAdditionalTypes(): Set<String> = setOf("peripheral_hub")
+
+    @LuaFunction(mainThread = true)
+    fun getPositionRemote(name: String): Map<String, Any>? {
+        val record = blockEntity.remotePeripherals.values.find { it.peripheralName == name } ?: return null
+        return mapOf(
+            "x" to record.targetBlock.x,
+            "y" to record.targetBlock.y,
+            "z" to record.targetBlock.z,
+            "direction" to record.direction.serializedName,
+        )
+    }
+
+    @LuaFunction(mainThread = true)
+    fun addPeripheral(pos: Map<*, *>, direction: String): MethodResult {
+        val targetPos = LuaInterpretation.asBlockPos(pos)
+        val targetDirection = Direction.entries.find { it.serializedName == direction.lowercase() }
+            ?: return MethodResult.of(false, "Direction should be one of: down, up, north, south, west, east")
+        val level = peripheralOwner.level as? ServerLevel ?: return MethodResult.of(false, "Peripheral proxy is not in a server level")
+        if (blockEntity.containsPos(targetPos)) return MethodResult.of(false, "Peripheral is already connected")
+        if (!blockEntity.isPosApplicable(targetPos)) return MethodResult.of(false, "Position is the proxy itself or too far away")
+        if (blockEntity.remotePeripherals.size >= PeripheralWorksConfig.peripheralProxyMaxCapacity) {
+            return MethodResult.of(false, "Too many peripherals already connected")
+        }
+        if (!level.isLoaded(targetPos)) return MethodResult.of(false, "Target position is not loaded")
+        if (level.getBlockState(targetPos).`is`(BlockTags.PERIPHERAL_PROXY_FORBIDDEN)) {
+            return MethodResult.of(false, "This block is forbidden to add to peripheral proxy")
+        }
+        val targetPeripheral = ComputerPlatformToolkit.get().getPeripheral(level, targetPos, targetDirection)
+            ?: return MethodResult.of(false, "This block does not contain a peripheral on the requested side")
+        blockEntity.togglePos(targetPos, targetDirection, targetPeripheral)
+        return MethodResult.of(true, blockEntity.remotePeripherals[targetPos]?.peripheralName)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
While playing with this mod, I felt that as a mod designed to enhance the CC:T experience, it could potentially offer a higher degree of automation efficiency by making the peripheral binding process fully self-contained within CC:T. Since binding a peripheral is already cost-free, I believe this does not affect the mod's balance.

## Overview
This PR introduces two new Lua APIs for the Peripheral Proxy (`getPositionRemote` and `addPeripheral`) and fixes a bug where bound peripherals would always connect from the north after a world reload.

## Changes

### 1. New API: `getPositionRemote(name)`
**Location:** `PeripheralProxyPeripheral.kt` ([line 25]
Allows querying the position and facing direction of a remote peripheral by its assigned name.

**Usage:**
```lua
local info = proxy.getPositionRemote("monitor_1")
Returns:

If the peripheral exists:

lua
{
    x = 100,
    y = 64,
    z = -20,
    direction = "north"
}
If the peripheral name is not registered: nil

This is a purely additive API and does not change any existing behavior.

2. New API: addPeripheral(position, direction)
Location: PeripheralProxyPeripheral.kt (same file as above)

Programmatically binds a peripheral at the given coordinates and facing direction. It reuses the core logic of the existing Configurator binding flow.

Usage:

lua
local success, result = proxy.addPeripheral(
    { x = 100, y = 64, z = -20 },
    "north"
)
Returns:

On success: true, "peripheral_name"

On failure: false, "failure_reason"

Checks performed internally:

Distance check

Capacity check

Forbidden binding tag check

Chunk loading check

Directional peripheral existence check

Synchronisation, persistence and mounting

This API only has an effect when called explicitly; it does not automatically alter any existing peripherals.

3. Fix: Direction handling after world reload
Location: PeripheralProxyBlockEntity.kt ([line 212]
Previous behavior:
When the world was reloaded, the code always attempted to fetch the peripheral from the north side:

kotlin
Direction.NORTH
New behavior:
The stored direction from the binding record is now used:

kotlin
record.direction
This is a bug fix. For blocks that expose a CC peripheral only on a specific side, connections will now be correctly restored after a reload.

Expected behavioral change:
A small number of bindings that were previously (incorrectly) connected from the north will now connect according to their actual saved direction. This is the intended and correct behavior.

**Motivation and Context**
The new APIs give players and programs more flexibility to inspect and manage remote peripheral bindings at runtime.

The direction bug prevented proxies from working reliably with directional peripherals across world reloads or dimension changes.

**How Has This Been Tested?**
getPositionRemote returns correct coordinates and direction for existing bindings, and nil for non-existent names.

addPeripheral successfully binds valid peripherals, and returns descriptive errors for invalid input (out of range, missing peripheral, blocked tag, etc.).

Existing bindings are unaffected unless explicitly modified via the new API.

After reloading the world, a proxy bound to a peripheral on the south side no longer incorrectly attempts to connect from the north; it reconnects using the saved direction.

**Checklist**
Code compiles and passes existing tests

New Lua APIs are documented (if applicable)

No breaking changes to existing APIs