### PR TITLE
fix(computercraft): apply ignore tag in forge peripheral provider

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/ComputerCraftProxy.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/computercraft/ComputerCraftProxy.kt
@@ -53,6 +53,10 @@ object ComputerCraftProxy {
     }
 
     fun lazyPeripheralProvider(level: Level, pos: BlockPos, side: Direction): Supplier<IPeripheral>? {
+        val state = level.getBlockState(pos)
+        if (state.`is`(BlockTags.IGNORE)) {
+            return null
+        }
         val plugins = collectPlugins(level, pos, side)
         if (plugins.isEmpty()) {
             return null


### PR DESCRIPTION
# Issue
The `peripheralworks:ignore` block tag (`BlockTags.IGNORE`) is correctly
checked in `ComputerCraftProxy.peripheralProvider`:
```kotlin
    fun peripheralProvider(level: Level, pos: BlockPos, state: BlockState, entity: BlockEntity?, side: Direction): IPeripheral? {
        if (state.`is`(BlockTags.IGNORE)) return null
        ......
    }
```
However, in the forge version, the peripheral provider is actually registered using `ComputerCraftProxy.lazyPeripheralProvider`, which doesn't check the tag at all.

# Fix
I added a check for the tag at the start of `ComputerCraftProxy.lazyPeripheralProvider`, mirroring the check in `peripheralProvider`