### PR TITLE
build: route dependencies through Maven proxy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,5 +27,7 @@ githubShaking {
 }
 
 repositories {
-    mavenCentral()
+    maven("https://mvn.siredvin.site/minecraft") {
+        name = "SirEdvin's Maven proxy"
+    }
 }

--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -22,18 +22,8 @@ vanillaShaking {
 repositories {
     mavenLocal()
     maven {
-        name = "TerraformersMC"
-        url = uri("https://maven.terraformersmc.com/")
-        content {
-            includeGroup("dev.emi")
-        }
-    }
-    maven {
-        name = "Jared's maven"
-        url = uri("https://maven.blamejared.com/")
-        content {
-            includeGroup("mezz.jei")
-        }
+        name = "SirEdvin's Maven proxy"
+        url = uri("https://mvn.siredvin.site/minecraft")
     }
 }
 

--- a/projects/fabric/build.gradle.kts
+++ b/projects/fabric/build.gradle.kts
@@ -11,7 +11,7 @@ val modBaseName: String by extra
 
 baseShaking {
     projectPart.set("fabric")
-    integrationRepositories.set(true)
+    integrationRepositories.set(false)
     shake()
 }
 
@@ -33,121 +33,9 @@ fabricShaking {
 
 repositories {
     mavenLocal()
-    // location of the maven that hosts JEI files since January 2023
     maven {
-        name = "Jared's maven"
-        url = uri("https://maven.blamejared.com/")
-        content {
-            includeGroup("mezz.jei")
-        }
-    }
-    maven {
-        name = "OwO maven"
-        url = uri("https://maven.wispforest.io")
-        content {
-            includeGroup("io.wispforest")
-        }
-    }
-    maven {
-        name = "Polymer repo"
-        url = uri("https://maven.nucleoid.xyz")
-        content {
-            includeGroup("eu.pb4")
-            includeGroup("xyz.nucleoid")
-        }
-    }
-    maven {
-        name = "OSS Sonatype Repo"
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-        content {
-            includeGroup("me.lucko")
-        }
-    }
-    maven {
-        name = "ModMenu maven"
-        url = uri("https://maven.terraformersmc.com/releases")
-        content {
-            includeGroup("com.terraformersmc")
-        }
-    }
-    // for reach entity attributes, required by Magna
-    maven {
-        url = uri("https://maven.jamieswhiteshirt.com/libs-release/")
-        content {
-            includeGroup("com.jamieswhiteshirt")
-        }
-    }
-    maven {
-        name = "Draylar maven"
-        url = uri("https://maven.draylar.dev/releases")
-        content {
-            includeGroup("dev.draylar")
-            includeGroup("dev.draylar.omega-config")
-        }
-    }
-    maven {
-        name = "Jitpack for MI"
-        url = uri("https://jitpack.io")
-        content {
-            /* For Magna */
-            includeGroup("com.github.Draylar.omega-config")
-        }
-    }
-    maven {
-        name = "Ladysnake Mods"
-        url = uri("https://maven.ladysnake.org/releases")
-        content {
-            includeGroup("io.github.ladysnake")
-            includeGroupByRegex("io\\.github\\.onyxstudios.*")
-        }
-    }
-    maven {
-        name = "devOS"
-        url = uri("https://mvn.devos.one/snapshots/")
-        content {
-            includeGroup("com.simibubi.create")
-            includeGroupByRegex("io\\.github\\.fabricators_of_create.*")
-            includeGroup("com.tterrag.registrate_fabric")
-            includeGroup("io.github.tropheusj")
-        }
-    }
-    maven {
-        name = "github packages via jitpack"
-        url = uri("https://jitpack.io")
-        content {
-            includeGroup("com.github.llamalad7.mixinextras")
-            includeGroup("com.github.Chocohead")
-        }
-    }
-    maven {
-        name = "Mod maven"
-        url = uri("https://modmaven.dev/")
-        content {
-            includeGroup("com.jozufozu.flywheel")
-        }
-    }
-    maven {
-        name = "TerraformersMC"
-        url = uri("https://maven.terraformersmc.com/")
-        content {
-            includeGroup("dev.emi")
-        }
-    }
-    maven {
-        name = "KubeJS's author maven"
-        url = uri("https://maven.latvian.dev/releases")
-        content {
-            includeGroup("dev.latvian.mods")
-            includeGroup("dev.latvian.apps")
-        }
-    }
-
-    maven {
-        name = "Jitpack for kubejs deps"
-        url = uri("https://jitpack.io")
-        content {
-            includeGroup("com.github.rtyley")
-        }
+        name = "SirEdvin's Maven proxy"
+        url = uri("https://mvn.siredvin.site/minecraft")
     }
 }
 

--- a/projects/forge/build.gradle.kts
+++ b/projects/forge/build.gradle.kts
@@ -10,7 +10,7 @@ val modBaseName: String by extra
 
 baseShaking {
     projectPart.set("forge")
-    integrationRepositories.set(true)
+    integrationRepositories.set(false)
     shake()
 }
 
@@ -32,100 +32,9 @@ forgeShaking {
 
 repositories {
     mavenLocal()
-    // location of the maven that hosts JEI files since January 2023
     maven {
-        name = "Jared's maven"
-        url = uri("https://maven.blamejared.com/")
-        content {
-            includeGroup("mezz.jei")
-        }
-    }
-    maven {
-        name = "Kotlin for Forge"
-        url = uri("https://thedarkcolour.github.io/KotlinForForge/")
-        content {
-            includeGroup("thedarkcolour")
-        }
-    }
-    // Integration dependencies
-    maven {
-        name = "KliKli Dev Repsy Maven (Occultism)"
-        url = uri("https://repo.repsy.io/mvn/klikli-dev/mods")
-        content {
-            includeGroup("com.klikli_dev")
-        }
-    }
-
-    maven {
-        name = "Curios Maven"
-        url = uri("https://maven.theillusivec4.top/")
-        content {
-            includeGroup("top.theillusivec4.curios")
-        }
-    }
-
-    maven {
-        name = "SBL Maven"
-        url = uri("https://dl.cloudsmith.io/public/tslat/sbl/maven/")
-        content {
-            includeGroup("net.tslat.smartbrainlib")
-        }
-    }
-    maven {
-        name = "Geckolib Maven"
-        url = uri("https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/")
-        content {
-            includeGroup("software.bernie.geckolib")
-            includeGroupByRegex("software\\.bernie.*")
-            includeGroup("com.eliotlash.mclib")
-        }
-    }
-    maven {
-        name = "tterrag maven"
-        url = uri("https://maven.tterrag.com/")
-        content {
-            includeGroup("com.tterrag.registrate")
-            includeGroup("com.jozufozu.flywheel")
-        }
-    }
-    maven {
-        name = "Create maven"
-        url = uri("https://maven.createmod.net")
-        content {
-            includeGroup("com.simibubi.create")
-            includeGroup("net.createmod.ponder")
-            includeGroup("dev.engine-room.flywheel")
-        }
-    }
-    maven {
-        name = "Occultism maven"
-        url = uri("https://dl.cloudsmith.io/public/klikli-dev/mods/maven/")
-        content {
-            includeGroup("com.klikli_dev")
-        }
-    }
-    maven {
-        name = "TerraformersMC"
-        url = uri("https://maven.terraformersmc.com/")
-        content {
-            includeGroup("dev.emi")
-        }
-    }
-    maven {
-        name = "Latvian mods, mostly KubeJS"
-        url = uri("https://maven.latvian.dev/releases")
-        content {
-            includeGroup("dev.latvian.mods")
-            includeGroup("dev.latvian.apps")
-        }
-    }
-
-    maven {
-        name = "Dependencies for kubej"
-        url = uri("https://jitpack.io")
-        content {
-            includeGroup("com.github.rtyley")
-        }
+        name = "SirEdvin's Maven proxy"
+        url = uri("https://mvn.siredvin.site/minecraft")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,24 +1,8 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         maven("https://mvn.siredvin.site/minecraft") {
-            name = "SirEdvin's Minecraft repository"
-            content {
-                includeGroup("net.minecraftforge")
-                includeGroup("net.minecraftforge.gradle")
-                includeGroup("org.parchmentmc")
-                includeGroup("org.parchmentmc.feather")
-                includeGroup("org.parchmentmc.data")
-                includeGroup("org.spongepowered")
-                includeGroup("org.spongepowered.gradle.vanilla")
-                includeGroup("net.fabricmc")
-                includeGroup("fabric-loom")
-                includeGroup("site.siredvin")
-                includeGroupByRegex("site.siredvin.*")
-            }
+            name = "SirEdvin's Maven proxy"
         }
-        maven("https://maven.kikugie.dev/snapshots") { name = "KikuGie Snapshots" }
     }
 
     resolutionStrategy {


### PR DESCRIPTION
## Summary
- route plugin and project dependency resolution through `https://mvn.siredvin.site/minecraft`
- remove direct third-party Maven repository declarations
- disable automatically injected integration repositories

## Verification
- `./gradlew :core:compileKotlin :fabric:compileKotlin :forge:compileKotlin --no-daemon`
- clean `./gradlew :forge:compileKotlin --no-daemon`
- `git diff --check`