### PR TITLE
Optimize network manager overlay rendering

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/FlareRenderer.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/FlareRenderer.kt
@@ -5,7 +5,6 @@ import com.mojang.blaze3d.platform.GlStateManager.DestFactor.ZERO
 import com.mojang.blaze3d.platform.GlStateManager.SourceFactor.ONE
 import com.mojang.blaze3d.platform.GlStateManager.SourceFactor.SRC_ALPHA
 import com.mojang.blaze3d.systems.RenderSystem
-import com.mojang.blaze3d.vertex.BufferUploader
 import com.mojang.blaze3d.vertex.DefaultVertexFormat
 import com.mojang.blaze3d.vertex.PoseStack
 import com.mojang.blaze3d.vertex.Tesselator
@@ -31,11 +30,13 @@ object FlareRenderer : AbstractRenderer() {
 
         super.initRenderer(matrices, camera)
 
-        RenderSystem.setShader(GameRenderer::getPositionTexShader)
+        RenderSystem.setShader(GameRenderer::getPositionColorTexShader)
         RenderSystem.setShaderTexture(0, flareTexture)
+        Tesselator.getInstance().builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR_TEX)
     }
 
     override fun uninitRenderer(matrices: PoseStack) {
+        Tesselator.getInstance().end()
         super.uninitRenderer(matrices)
 
         RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f)
@@ -65,29 +66,23 @@ object FlareRenderer : AbstractRenderer() {
         val renderSize = size * 0.2f + Mth.sin(ticks / 100.0f + color.offset) / 16.0f
 
         // Prepare to render
-        val tessellator = Tesselator.getInstance()
         val matrix4f = matrices.last().pose()
 
         // Inner highlight
-        RenderSystem.setShaderColor(color.r, color.g, color.b, 0.5f)
-        renderQuad(tessellator, matrix4f, renderSize)
+        renderQuad(matrix4f, renderSize, color, 0.5f)
 
         // Outer aura
-        RenderSystem.setShaderColor(color.r, color.g, color.b, 0.2f)
-        renderQuad(tessellator, matrix4f, renderSize * 2)
+        renderQuad(matrix4f, renderSize * 2, color, 0.2f)
 
         matrices.popPose()
     }
 
-    private fun renderQuad(tessellator: Tesselator, matrix4f: Matrix4f, size: Float) {
-        val buffer = tessellator.builder
-
-        buffer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX)
-        buffer.vertex(matrix4f, -size, -size, 0f).uv(0f, 1f).endVertex()
-        buffer.vertex(matrix4f, -size, +size, 0f).uv(1f, 1f).endVertex()
-        buffer.vertex(matrix4f, +size, +size, 0f).uv(1f, 0f).endVertex()
-        buffer.vertex(matrix4f, +size, -size, 0f).uv(0f, 0f).endVertex()
-        BufferUploader.drawWithShader(buffer.end())
+    private fun renderQuad(matrix4f: Matrix4f, size: Float, color: FlareColor, alpha: Float) {
+        val buffer = Tesselator.getInstance().builder
+        buffer.vertex(matrix4f, -size, -size, 0f).color(color.r, color.g, color.b, alpha).uv(0f, 1f).endVertex()
+        buffer.vertex(matrix4f, -size, +size, 0f).color(color.r, color.g, color.b, alpha).uv(1f, 1f).endVertex()
+        buffer.vertex(matrix4f, +size, +size, 0f).color(color.r, color.g, color.b, alpha).uv(1f, 0f).endVertex()
+        buffer.vertex(matrix4f, +size, -size, 0f).color(color.r, color.g, color.b, alpha).uv(0f, 0f).endVertex()
     }
     data class FlareColor(val r: Float, val g: Float, val b: Float, val offset: Float = 0.1f)
 }

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/NetworkManagerClientRender.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/NetworkManagerClientRender.kt
@@ -14,13 +14,13 @@ import net.minecraft.client.renderer.GameRenderer
 import net.minecraft.client.renderer.LevelRenderer
 import net.minecraft.client.renderer.LightTexture
 import net.minecraft.client.renderer.MultiBufferSource
+import net.minecraft.client.renderer.culling.Frustum
 import net.minecraft.core.BlockPos
 import net.minecraft.network.chat.Component
 import net.minecraft.world.phys.AABB
 import org.joml.Matrix4f
 import site.siredvin.peripheralworks.common.blockentity.NetworkManagerBlockEntity
 import site.siredvin.peripheralworks.subsystem.configurator.NetworkManagerMode
-import kotlin.math.sqrt
 
 object NetworkManagerClientRender : ConfigurationModeRender {
 
@@ -46,9 +46,14 @@ object NetworkManagerClientRender : ConfigurationModeRender {
         val matrix4f = matrices.last().pose()
 
         val font = Minecraft.getInstance().font
-        val component = Component.literal(text).withStyle { it.withBold(bold) }
-        val offset = (-font.width(component) / 2).toFloat()
-        font.drawInBatch(component, offset, 0f, color, false, matrix4f, buffer, Font.DisplayMode.SEE_THROUGH, 0, LightTexture.FULL_BRIGHT)
+        if (bold) {
+            val component = Component.literal(text).withStyle { it.withBold(true) }
+            val offset = (-font.width(component) / 2).toFloat()
+            font.drawInBatch(component, offset, 0f, color, false, matrix4f, buffer, Font.DisplayMode.SEE_THROUGH, 0, LightTexture.FULL_BRIGHT)
+        } else {
+            val offset = (-font.width(text) / 2).toFloat()
+            font.drawInBatch(text, offset, 0f, color, false, matrix4f, buffer, Font.DisplayMode.SEE_THROUGH, 0, LightTexture.FULL_BRIGHT)
+        }
 
         matrices.popPose()
     }
@@ -63,44 +68,51 @@ object NetworkManagerClientRender : ConfigurationModeRender {
     ) {
         val entity = minecraft.level?.getBlockEntity(source) as? NetworkManagerBlockEntity ?: return
         val playerPos = minecraft.player!!.position()
-        val range = entity.range
+        val rangeSquared = entity.range.toDouble() * entity.range
         val stack = minecraft.player!!.mainHandItem
         val selected = NetworkManagerMode.getSelectedGroup(stack)
-        val peripherals = entity.clientBlockCache.entries.mapNotNull { (pos, instructions) ->
-            if (sqrt(pos.distToCenterSqr(playerPos.x(), playerPos.y(), playerPos.z())) >= range) return@mapNotNull null
-            val selectedGroups = instructions.groups.filter { group -> selected != null && (group == selected || entity.delimiter.isNotEmpty() && group.startsWith(selected + entity.delimiter)) }.sorted()
-            val target = when {
-                selectedGroups.isNotEmpty() -> NetworkManagerMode.RenderTarget.SELECTED
-                instructions.groups.isNotEmpty() -> NetworkManagerMode.RenderTarget.GROUPED
-                else -> NetworkManagerMode.RenderTarget.UNGROUPED
-            }
-            val groups = if (target == NetworkManagerMode.RenderTarget.SELECTED) selectedGroups else instructions.groups.sorted()
-            // ponytail: one stable color avoids overlapping effects for multi-group peripherals.
-            val color = groups.firstOrNull()?.let { entity.peripheralGroups[it]?.color }?.takeIf { it >= 0 } ?: 0xffffff
-            RenderedPeripheral(pos, instructions, groups, NetworkManagerMode.getTextStyle(stack, target), NetworkManagerMode.getBoxStyle(stack, target), color)
-        }
-
-        CommonRenderer.initRenderer(poseStack, camera)
-        RenderSystem.disableDepthTest()
-        RenderSystem.disableCull()
-        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F)
-        RenderSystem.depthMask(false)
-        peripherals.forEach {
-            when (it.boxStyle) {
-                NetworkManagerMode.BoxStyle.OUTLINE -> renderBox(poseStack, it, false)
-                NetworkManagerMode.BoxStyle.FILLED -> renderBox(poseStack, it, true)
-                else -> Unit
+        val selectedPrefix = selected?.takeIf { entity.delimiter.isNotEmpty() }?.plus(entity.delimiter)
+        val textStyles = NetworkManagerMode.RenderTarget.entries.map { NetworkManagerMode.getTextStyle(stack, it) }
+        val boxStyles = NetworkManagerMode.RenderTarget.entries.map { NetworkManagerMode.getBoxStyle(stack, it) }
+        val frustum = Frustum(poseStack.last().pose(), projectionMatrix).apply { prepare(camera.position.x, camera.position.y, camera.position.z) }
+        val peripherals = buildList {
+            entity.clientBlockCache.forEach { (pos, instructions) ->
+                if (pos.distToCenterSqr(playerPos.x, playerPos.y, playerPos.z) >= rangeSquared || !frustum.isVisible(AABB(pos).inflate(1.0))) return@forEach
+                val selectedGroups = if (selected == null) emptyList() else instructions.groups.filter { group -> group == selected || selectedPrefix != null && group.startsWith(selectedPrefix) }
+                val target = when {
+                    selectedGroups.isNotEmpty() -> NetworkManagerMode.RenderTarget.SELECTED
+                    instructions.groups.isNotEmpty() -> NetworkManagerMode.RenderTarget.GROUPED
+                    else -> NetworkManagerMode.RenderTarget.UNGROUPED
+                }
+                val textStyle = textStyles[target.ordinal]
+                val boxStyle = boxStyles[target.ordinal]
+                if (textStyle == NetworkManagerMode.TextStyle.NONE && boxStyle == NetworkManagerMode.BoxStyle.NONE) return@forEach
+                val groups = if (target == NetworkManagerMode.RenderTarget.SELECTED) selectedGroups else instructions.groups
+                // ponytail: one stable color avoids overlapping effects for multi-group peripherals.
+                val color = groups.firstOrNull()?.let { entity.peripheralGroups[it]?.color }?.takeIf { it >= 0 } ?: 0xffffff
+                add(RenderedPeripheral(pos, instructions, groups, textStyle, boxStyle, color))
             }
         }
-        RenderSystem.enableDepthTest()
-        RenderSystem.enableCull()
-        RenderSystem.depthMask(true)
-        CommonRenderer.uninitRenderer(poseStack)
+        if (peripherals.isEmpty()) return
 
-        val flares = peripherals.filter { it.boxStyle == NetworkManagerMode.BoxStyle.FLARE }
-        if (flares.isNotEmpty()) {
+        if (peripherals.any { it.boxStyle == NetworkManagerMode.BoxStyle.OUTLINE || it.boxStyle == NetworkManagerMode.BoxStyle.FILLED }) {
+            CommonRenderer.initRenderer(poseStack, camera)
+            RenderSystem.disableDepthTest()
+            RenderSystem.disableCull()
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F)
+            RenderSystem.depthMask(false)
+            renderBoxes(poseStack, peripherals, false)
+            renderBoxes(poseStack, peripherals, true)
+            RenderSystem.enableDepthTest()
+            RenderSystem.enableCull()
+            RenderSystem.depthMask(true)
+            CommonRenderer.uninitRenderer(poseStack)
+        }
+
+        if (peripherals.any { it.boxStyle == NetworkManagerMode.BoxStyle.FLARE }) {
             FlareRenderer.initRenderer(poseStack, camera)
-            flares.forEach {
+            peripherals.forEach {
+                if (it.boxStyle != NetworkManagerMode.BoxStyle.FLARE) return@forEach
                 val color = it.color
                 FlareRenderer.renderFlare(
                     poseStack,
@@ -116,54 +128,65 @@ object NetworkManagerClientRender : ConfigurationModeRender {
             FlareRenderer.uninitRenderer(poseStack)
         }
 
-        CommonRenderer.initRenderer(poseStack, camera)
-        RenderSystem.disableDepthTest()
-        RenderSystem.disableCull()
-        RenderSystem.depthMask(false)
-        val buffer = minecraft.renderBuffers().bufferSource()
-        peripherals.forEach {
-            if (it.textStyle == NetworkManagerMode.TextStyle.NONE) return@forEach
-            val bold = it.textStyle == NetworkManagerMode.TextStyle.BOLD
-            var baseHeight = 1.2
-            renderText(poseStack, it.instructions.peripheralName, it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, bold = bold)
-            for (extraName in it.instructions.extraNames) {
-                baseHeight += 0.15
-                renderText(poseStack, extraName, it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, 0xff0000, bold)
+        if (peripherals.any { it.textStyle != NetworkManagerMode.TextStyle.NONE }) {
+            CommonRenderer.initRenderer(poseStack, camera)
+            RenderSystem.disableDepthTest()
+            RenderSystem.disableCull()
+            RenderSystem.depthMask(false)
+            val buffer = minecraft.renderBuffers().bufferSource()
+            peripherals.forEach {
+                if (it.textStyle == NetworkManagerMode.TextStyle.NONE) return@forEach
+                val bold = it.textStyle == NetworkManagerMode.TextStyle.BOLD
+                var baseHeight = 1.2
+                renderText(poseStack, it.instructions.peripheralName, it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, bold = bold)
+                for (extraName in it.instructions.extraNames) {
+                    baseHeight += 0.15
+                    renderText(poseStack, extraName, it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, 0xff0000, bold)
+                }
+                for (group in it.groups) {
+                    baseHeight += 0.15
+                    val groupColor = entity.peripheralGroups[group]?.color?.takeIf { color -> color >= 0 } ?: 0xffffff
+                    renderText(poseStack, "group:$group", it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, groupColor, bold)
+                }
             }
-            for (group in it.groups) {
-                baseHeight += 0.15
-                val groupColor = entity.peripheralGroups[group]?.color?.takeIf { color -> color >= 0 } ?: 0xffffff
-                renderText(poseStack, "group:$group", it.pos.x + 0.5, it.pos.y + baseHeight, it.pos.z + 0.5, buffer, groupColor, bold)
-            }
+            buffer.endBatch()
+            RenderSystem.enableDepthTest()
+            RenderSystem.enableCull()
+            RenderSystem.depthMask(true)
+            CommonRenderer.uninitRenderer(poseStack)
         }
-        buffer.endBatch()
-        RenderSystem.enableDepthTest()
-        RenderSystem.enableCull()
-        RenderSystem.depthMask(true)
-        CommonRenderer.uninitRenderer(poseStack)
     }
 
-    private fun renderBox(poseStack: PoseStack, peripheral: RenderedPeripheral, filled: Boolean) {
-        val red = (peripheral.color shr 16 and 0xff) / 255f
-        val green = (peripheral.color shr 8 and 0xff) / 255f
-        val blue = (peripheral.color and 0xff) / 255f
-        val box = AABB(peripheral.pos).inflate(0.01)
+    private fun renderBoxes(poseStack: PoseStack, peripherals: List<RenderedPeripheral>, filled: Boolean) {
+        val style = if (filled) NetworkManagerMode.BoxStyle.FILLED else NetworkManagerMode.BoxStyle.OUTLINE
+        if (peripherals.none { it.boxStyle == style }) return
         val buffer = Tesselator.getInstance().builder
-        RenderSystem.disableDepthTest()
         if (filled) {
             RenderSystem.enableBlend()
             RenderSystem.defaultBlendFunc()
             RenderSystem.setShader(GameRenderer::getPositionColorShader)
             buffer.begin(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR)
-            LevelRenderer.addChainedFilledBoxVertices(poseStack, buffer, box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ, red, green, blue, 0.45f)
-            BufferUploader.drawWithShader(buffer.end())
-            RenderSystem.disableBlend()
         } else {
             RenderSystem.setShader(GameRenderer::getRendertypeLinesShader)
             RenderSystem.lineWidth(4f)
             buffer.begin(VertexFormat.Mode.LINES, DefaultVertexFormat.POSITION_COLOR_NORMAL)
-            LevelRenderer.renderLineBox(poseStack, buffer, box, red, green, blue, 1f)
-            BufferUploader.drawWithShader(buffer.end())
+        }
+        peripherals.forEach {
+            if (it.boxStyle != style) return@forEach
+            val red = (it.color shr 16 and 0xff) / 255f
+            val green = (it.color shr 8 and 0xff) / 255f
+            val blue = (it.color and 0xff) / 255f
+            val box = AABB(it.pos).inflate(0.01)
+            if (filled) {
+                LevelRenderer.addChainedFilledBoxVertices(poseStack, buffer, box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ, red, green, blue, 0.45f)
+            } else {
+                LevelRenderer.renderLineBox(poseStack, buffer, box, red, green, blue, 1f)
+            }
+        }
+        BufferUploader.drawWithShader(buffer.end())
+        if (filled) {
+            RenderSystem.disableBlend()
+        } else {
             RenderSystem.lineWidth(1f)
         }
     }

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/PeripheralProxyClientRender.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/PeripheralProxyClientRender.kt
@@ -51,8 +51,8 @@ object PeripheralProxyClientRender : ConfigurationModeRender {
         camera: Camera,
         projectionMatrix: Matrix4f,
     ) {
-        FlareRenderer.initRenderer(poseStack, camera)
         val entity = minecraft.level?.getBlockEntity(source) as? PeripheralProxyBlockEntity ?: return
+        FlareRenderer.initRenderer(poseStack, camera)
         FlareRenderer.renderFlare(
             poseStack,
             camera,

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/RemoteObserverClientRender.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/client/configurator/RemoteObserverClientRender.kt
@@ -20,8 +20,8 @@ object RemoteObserverClientRender : ConfigurationModeRender {
         camera: Camera,
         projectionMatrix: Matrix4f,
     ) {
-        FlareRenderer.initRenderer(poseStack, camera)
         val entity = minecraft.level?.getBlockEntity(source) as? RemoteObserverBlockEntity ?: return
+        FlareRenderer.initRenderer(poseStack, camera)
         FlareRenderer.renderFlare(
             poseStack,
             camera,

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/NetworkManagerBlockEntity.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/NetworkManagerBlockEntity.kt
@@ -352,6 +352,7 @@ class NetworkManagerBlockEntity(blockPos: BlockPos, blockState: BlockState) :
                     }
                 }
             }
+            clientBlockCache.values.forEach { it.groups.sort() }
         }
         return state ?: blockState
     }


### PR DESCRIPTION
## Summary
- frustum-cull network peripherals and skip disabled render passes
- batch outline, filled-box, and flare geometry to reduce draw submissions
- move stable style and group ordering work out of per-peripheral frame processing

## Verification
- `./gradlew build --no-daemon`
- `xvfb-run -a ./gradlew clientGameTest --no-daemon` (Fabric passed; Forge dependency config race on combined run)
- `xvfb-run -a ./gradlew :forge:runClientGameTest --no-daemon` (retry passed)
- `xvfb-run -a ./gradlew gameTest --no-daemon -PminimalTestEnvironment`