### PR TITLE
Integrate typed peripheral package

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ val setupSubproject = subprojectShaking::setupSubproject
 
 
 subprojects {
-    if (name != "typescript-tests") {
+    if (name !in setOf("typed-peripheral-unlimitedperipheralworks", "typescript-tests")) {
         setupSubproject(this)
     }
 }

--- a/projects/typed-peripheral-unlimitedperipheralworks/.gitignore
+++ b/projects/typed-peripheral-unlimitedperipheralworks/.gitignore
@@ -1,0 +1,2 @@
+*.lua
+node_modules

--- a/projects/typed-peripheral-unlimitedperipheralworks/build.gradle.kts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.github.gradle.node.npm.task.NpmTask
 
 plugins {
+    base
     id("com.github.node-gradle.node") version "7.1.0"
 }
 
@@ -13,16 +14,26 @@ node {
     npmInstallCommand.set("ci")
 }
 
-tasks.npmInstall {
-    dependsOn(":typed-peripheral-unlimitedperipheralworks:compileTypeScript")
-}
-
-val compileTestLua by tasks.registering(NpmTask::class) {
+val compileTypeScript by tasks.registering(NpmTask::class) {
     dependsOn(tasks.npmInstall)
     npmCommand.set(listOf("run", "build"))
     inputs.files(fileTree(projectDir) {
-        include("package.json", "package-lock.json", "tsconfig.json", "build.mjs", "src/**/*.ts")
+        include("package.json", "package-lock.json", "tsconfig.json", "**/*.ts")
         exclude("node_modules/**")
     })
-    outputs.dir(layout.buildDirectory.dir("generated/test-lua"))
+    outputs.files(fileTree(projectDir) {
+        include("**/*.lua")
+        exclude("node_modules/**")
+    })
+}
+
+tasks.assemble {
+    dependsOn(compileTypeScript)
+}
+
+tasks.clean {
+    delete(fileTree(projectDir) {
+        include("**/*.lua")
+        exclude("node_modules/**")
+    })
 }

--- a/projects/typed-peripheral-unlimitedperipheralworks/events/networkManagerGroupChange.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/events/networkManagerGroupChange.d.ts
@@ -1,0 +1,11 @@
+import * as events from "@siredvin/cc-events";
+export declare const NETWORK_MANAGER_GROUP_CHANGE = "network_manager_group_change";
+export declare class NetworkManagerGroupChangeEvent extends events.BaseEvent<[
+    string,
+    "added" | "removed",
+    string
+]> {
+    getGroup(): string;
+    getAction(): "added" | "removed";
+    getPeripheral(): string;
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/events/networkManagerGroupChange.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/events/networkManagerGroupChange.ts
@@ -1,0 +1,25 @@
+import * as events from "@siredvin/cc-events";
+
+export const NETWORK_MANAGER_GROUP_CHANGE = "network_manager_group_change";
+
+export class NetworkManagerGroupChangeEvent extends events.BaseEvent<
+    [string, "added" | "removed", string]
+> {
+    getGroup(): string {
+        return this.args[0];
+    }
+
+    getAction(): "added" | "removed" {
+        return this.args[1];
+    }
+
+    getPeripheral(): string {
+        return this.args[2];
+    }
+}
+
+events.eventInitializers.set(
+    NETWORK_MANAGER_GROUP_CHANGE,
+    (name: string, args: [string, "added" | "removed", string]) =>
+        new NetworkManagerGroupChangeEvent(name, args)
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/informativeRegistry.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/informativeRegistry.d.ts
@@ -1,0 +1,11 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { FluidDetail, IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface InformativeRegistry extends ConfigurationAPI<object> {
+    list(listName: "list" | "item" | "fluid" | "block" | "itemTags" | "fluidTags" | "blockTags"): string[];
+    describe(listName: "itemTags" | "blockTags" | "fluidTags", tag: string): string[];
+    describe(listName: "item", id: string): ItemDetail;
+    describe(listName: "fluid", id: string): FluidDetail;
+    describe(listName: "list" | "block", id: string): LuaTable;
+}
+export declare const informativeRegistryProvider: IPeripheralProvider<InformativeRegistry>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/informativeRegistry.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/informativeRegistry.ts
@@ -1,0 +1,29 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { FluidDetail, IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface InformativeRegistry extends ConfigurationAPI<object> {
+    list(
+        listName:
+            | "list"
+            | "item"
+            | "fluid"
+            | "block"
+            | "itemTags"
+            | "fluidTags"
+            | "blockTags"
+    ): string[];
+    describe(
+        listName: "itemTags" | "blockTags" | "fluidTags",
+        tag: string
+    ): string[];
+    describe(listName: "item", id: string): ItemDetail;
+    describe(listName: "fluid", id: string): FluidDetail;
+    describe(listName: "list" | "block", id: string): LuaTable;
+}
+
+export const informativeRegistryProvider =
+    new IPeripheralProvider<InformativeRegistry>(
+        "informative_registry",
+        () => null
+    );

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/basin.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/basin.d.ts
@@ -1,0 +1,8 @@
+import { FluidStorageAPI } from "@siredvin/typed-peripheral-api/fluid_storage";
+import { ExtendedInventoryAPI } from "@siredvin/typed-peripheral-api/inventory_extended";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { CreateFilterableAPI } from "./filterable_api";
+/** @noSelf **/
+export interface CreateBasin extends ExtendedInventoryAPI, CreateFilterableAPI, FluidStorageAPI {
+}
+export declare const basinProvider: IPeripheralProvider<CreateBasin>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/basin.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/basin.ts
@@ -1,0 +1,15 @@
+import { FluidStorageAPI } from "@siredvin/typed-peripheral-api/fluid_storage";
+import { ExtendedInventoryAPI } from "@siredvin/typed-peripheral-api/inventory_extended";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { CreateFilterableAPI } from "./filterable_api";
+
+/** @noSelf **/
+export interface CreateBasin
+    extends ExtendedInventoryAPI,
+        CreateFilterableAPI,
+        FluidStorageAPI {}
+
+export const basinProvider = new IPeripheralProvider<CreateBasin>(
+    "create:basin",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/filterable_api.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/filterable_api.d.ts
@@ -1,0 +1,6 @@
+/** @noSelf **/
+export declare interface CreateFilterableAPI extends IPeripheral {
+    getFilterName(): string;
+    setFilterItem(id: string): any;
+    clearFilterItem(): any;
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/filterable_api.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/filterable_api.ts
@@ -1,0 +1,6 @@
+/** @noSelf **/
+export declare interface CreateFilterableAPI extends IPeripheral {
+    getFilterName(): string;
+    setFilterItem(id: string);
+    clearFilterItem();
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/mechanical_saw.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/mechanical_saw.d.ts
@@ -1,0 +1,7 @@
+import { ExtendedInventoryAPI } from "@siredvin/typed-peripheral-api/inventory_extended";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { CreateFilterableAPI } from "./filterable_api";
+/** @noSelf **/
+export interface CreateMechanicalSaw extends ExtendedInventoryAPI, CreateFilterableAPI {
+}
+export declare const mechanicalSawProvider: IPeripheralProvider<CreateMechanicalSaw>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/mechanical_saw.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/create/mechanical_saw.ts
@@ -1,0 +1,14 @@
+import { ExtendedInventoryAPI } from "@siredvin/typed-peripheral-api/inventory_extended";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { CreateFilterableAPI } from "./filterable_api";
+
+/** @noSelf **/
+export interface CreateMechanicalSaw
+    extends ExtendedInventoryAPI,
+        CreateFilterableAPI {}
+
+export const mechanicalSawProvider =
+    new IPeripheralProvider<CreateMechanicalSaw>(
+        "create:mechanical_saw",
+        () => null
+    );

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/base.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/base.d.ts
@@ -1,0 +1,28 @@
+export declare interface EmiEmptyIngredient {
+    type: "empty";
+}
+export declare interface EMIMultiIngredient {
+    candidates: EMIIngredient[];
+    amount: number;
+}
+export declare interface EmiTagIngredient {
+    type: "tag";
+    key: string;
+    tag_type: "item" | "fluid" | "unknown";
+    amount: number;
+}
+export declare interface EMIItemIngredient {
+    name: string;
+    count: number;
+    chance: number;
+    type: "item";
+    [key: string]: any;
+}
+export declare interface EMIFluidIngredient {
+    name: string;
+    displayName: string;
+    amount: number;
+    chance: number;
+    type: "fluid";
+}
+export declare type EMIIngredient = EMIItemIngredient | EMIFluidIngredient | EmiEmptyIngredient | EMIMultiIngredient | EmiTagIngredient;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/base.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/base.ts
@@ -1,0 +1,38 @@
+export declare interface EmiEmptyIngredient {
+    type: "empty";
+}
+
+export declare interface EMIMultiIngredient {
+    candidates: EMIIngredient[];
+    amount: number;
+}
+
+export declare interface EmiTagIngredient {
+    type: "tag";
+    key: string;
+    tag_type: "item" | "fluid" | "unknown"
+    amount: number;
+}
+
+export declare interface EMIItemIngredient {
+    name: string;
+    count: number;
+    chance: number;
+    type: "item";
+    [key: string]: any;
+}
+
+export declare interface EMIFluidIngredient {
+    name: string;
+    displayName: string;
+    amount: number;
+    chance: number;
+    type: "fluid";
+}
+
+export declare type EMIIngredient =
+    | EMIItemIngredient
+    | EMIFluidIngredient
+    | EmiEmptyIngredient
+    | EMIMultiIngredient
+    | EmiTagIngredient;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiIngredientPaste.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiIngredientPaste.d.ts
@@ -1,0 +1,9 @@
+import * as events from "@siredvin/cc-events";
+import { EMIFluidIngredient, EMIItemIngredient } from "./base";
+export declare const EMI_INGREDIENT_PASTE = "emi_ingredient_paste";
+export declare class EmiIngredientPasteEvent extends events.BaseEvent<[
+    EMIItemIngredient | EMIFluidIngredient
+]> {
+    getIngridient(): EMIItemIngredient | EMIFluidIngredient;
+    static create(ingredient: EMIItemIngredient | EMIFluidIngredient): EmiIngredientPasteEvent;
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiIngredientPaste.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiIngredientPaste.ts
@@ -1,0 +1,22 @@
+import * as events from "@siredvin/cc-events";
+import { EMIFluidIngredient, EMIIngredient, EMIItemIngredient } from "./base";
+
+export const EMI_INGREDIENT_PASTE = "emi_ingredient_paste";
+
+export class EmiIngredientPasteEvent extends events.BaseEvent<
+    [EMIItemIngredient | EMIFluidIngredient]
+> {
+    getIngridient(): EMIItemIngredient | EMIFluidIngredient {
+        return this.args[0];
+    }
+
+    public static create(ingredient: EMIItemIngredient | EMIFluidIngredient) {
+        return new EmiIngredientPasteEvent(EMI_INGREDIENT_PASTE, [ingredient]);
+    }
+}
+
+events.eventInitializers.set(
+    EMI_INGREDIENT_PASTE,
+    (name: string, args: [EMIItemIngredient | EMIFluidIngredient]) =>
+        new EmiIngredientPasteEvent(name, args)
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiRecipePaste.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiRecipePaste.d.ts
@@ -1,0 +1,15 @@
+import * as events from "@siredvin/cc-events";
+import { EMIIngredient } from "./base";
+export declare const EMI_RECIPE_PASTE = "emi_recipe_paste";
+export declare interface EmiRecipe {
+    inputs: EMIIngredient[];
+    outputs: EMIIngredient[];
+    catalysts: EMIIngredient[];
+    category: string;
+    extra?: object;
+    id: string;
+}
+export declare class EMIRecipePasteEvent extends events.BaseEvent<[EmiRecipe]> {
+    getRecipe(): EmiRecipe;
+    static create(recipe: EmiRecipe): EMIRecipePasteEvent;
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiRecipePaste.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/emi/emiRecipePaste.ts
@@ -1,0 +1,28 @@
+import * as events from "@siredvin/cc-events";
+import { EMIIngredient } from "./base";
+
+export const EMI_RECIPE_PASTE = "emi_recipe_paste";
+
+export declare interface EmiRecipe {
+    inputs: EMIIngredient[];
+    outputs: EMIIngredient[];
+    catalysts: EMIIngredient[];
+    category: string;
+    extra?: object;
+    id: string;
+}
+
+export class EMIRecipePasteEvent extends events.BaseEvent<[EmiRecipe]> {
+    getRecipe(): EmiRecipe {
+        return this.args[0];
+    }
+
+    public static create(recipe: EmiRecipe) {
+        return new EMIRecipePasteEvent(EMI_RECIPE_PASTE, [recipe]);
+    }
+}
+
+events.eventInitializers.set(
+    EMI_RECIPE_PASTE,
+    (name: string, args: [EmiRecipe]) => new EMIRecipePasteEvent(name, args)
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/controllable.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/controllable.d.ts
@@ -1,0 +1,8 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface ControllableMachine extends ConfigurationAPI<object> {
+    isWorkingEnabled(): boolean;
+    setWorkingEnabled(value: boolean): any;
+}
+export declare const workableProvider: IPeripheralProvider<ControllableMachine>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/controllable.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/controllable.ts
@@ -1,0 +1,13 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface ControllableMachine extends ConfigurationAPI<object> {
+    isWorkingEnabled(): boolean;
+    setWorkingEnabled(value: boolean);
+}
+
+export const workableProvider = new IPeripheralProvider<ControllableMachine>(
+    "gtceu:controllable",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/machine.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/machine.d.ts
@@ -1,0 +1,7 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface Machine extends ConfigurationAPI<object> {
+    getRecipeTypes(): string[];
+}
+export declare const machineProvider: IPeripheralProvider<Machine>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/machine.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/machine.ts
@@ -1,0 +1,12 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface Machine extends ConfigurationAPI<object> {
+    getRecipeTypes(): string[];
+}
+
+export const machineProvider = new IPeripheralProvider<Machine>(
+    "gtceu:machine",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/multiblock_machine.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/multiblock_machine.d.ts
@@ -1,0 +1,7 @@
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { Machine } from "./machine";
+/** @noSelf **/
+export interface MultiblockMachine extends Machine {
+    getPartNames(): string[];
+}
+export declare const multiblockMachineProvider: IPeripheralProvider<MultiblockMachine>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/multiblock_machine.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/multiblock_machine.ts
@@ -1,0 +1,12 @@
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { Machine } from "./machine";
+
+/** @noSelf **/
+export interface MultiblockMachine extends Machine {
+    getPartNames(): string[];
+}
+
+export const multiblockMachineProvider = new IPeripheralProvider<MultiblockMachine>(
+    "gtceu:multiblock_machine",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/workable.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/workable.d.ts
@@ -1,0 +1,7 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface WorkableMachine extends ConfigurationAPI<object> {
+    isActive(): boolean;
+}
+export declare const workableProvider: IPeripheralProvider<WorkableMachine>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/workable.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/gtceu/workable.ts
@@ -1,0 +1,12 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface WorkableMachine extends ConfigurationAPI<object> {
+    isActive(): boolean;
+}
+
+export const workableProvider = new IPeripheralProvider<WorkableMachine>(
+    "gtceu:workable",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/transmutation_table.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/transmutation_table.d.ts
@@ -1,0 +1,13 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { InventoryViewAPI } from "@siredvin/typed-peripheral-api/inventory_view";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface TransmutationTable extends ConfigurationAPI<object>, InventoryViewAPI {
+    getAvailableItems(): (ItemDetail & {
+        EMC: number;
+    })[];
+    getEMC(): number;
+    syntize(id: string, amount: number): Result;
+    transmute(slot: number): Result;
+}
+export declare const transmutationTableProvider: IPeripheralProvider<TransmutationTable>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/transmutation_table.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/transmutation_table.ts
@@ -1,0 +1,19 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { InventoryViewAPI } from "@siredvin/typed-peripheral-api/inventory_view";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface TransmutationTable
+    extends ConfigurationAPI<object>,
+        InventoryViewAPI {
+    getAvailableItems(): (ItemDetail & { EMC: number })[];
+    getEMC(): number;
+    syntize(id: string, amount: number): Result;
+    transmute(slot: number): Result;
+}
+
+export const transmutationTableProvider =
+    new IPeripheralProvider<TransmutationTable>(
+        "transmutation_table",
+        () => null
+    );

--- a/projects/typed-peripheral-unlimitedperipheralworks/networkManager.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/networkManager.d.ts
@@ -1,0 +1,18 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface NetworkManager extends ConfigurationAPI<object> {
+    getGroups(): string[];
+    addGroup(group: string): Result;
+    removeGroup(group: string): Result;
+    add(group: string, peripheral: string): Result;
+    remove(group: string, peripheral: string): Result;
+    setGroupColor(group: string, color: number): Result;
+    get(group: string): LuaMultiReturn<string[]>;
+    getDistanceBetween(first: string, second: string): {
+        x: number;
+        y: number;
+        z: number;
+    };
+}
+export declare const networkManagerProvider: IPeripheralProvider<NetworkManager>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/networkManager.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/networkManager.ts
@@ -1,0 +1,22 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface NetworkManager extends ConfigurationAPI<object> {
+    getGroups(): string[];
+    addGroup(group: string): Result;
+    removeGroup(group: string): Result;
+    add(group: string, peripheral: string): Result;
+    remove(group: string, peripheral: string): Result;
+    setGroupColor(group: string, color: number): Result;
+    get(group: string): LuaMultiReturn<string[]>;
+    getDistanceBetween(
+        first: string,
+        second: string
+    ): { x: number; y: number; z: number };
+}
+
+export const networkManagerProvider = new IPeripheralProvider<NetworkManager>(
+    "network_manager",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/package-lock.json
+++ b/projects/typed-peripheral-unlimitedperipheralworks/package-lock.json
@@ -1,0 +1,263 @@
+{
+    "name": "@siredvin/typed-peripheral-unlimitedperipheralworks",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@siredvin/typed-peripheral-unlimitedperipheralworks",
+            "version": "0.1.0",
+            "license": "MIT",
+            "dependencies": {
+                "@jackmacwindows/lua-types": "^2.13.1",
+                "@siredvin/api-types": "1.1.0",
+                "@siredvin/cc-events": "*",
+                "@siredvin/cc-types": "1.1.0",
+                "@siredvin/craftos-types": "1.2.0",
+                "@siredvin/typed-peripheral-api": "0.1.0",
+                "@siredvin/typed-peripheral-base": "0.4.0"
+            },
+            "devDependencies": {
+                "typescript": "*",
+                "typescript-to-lua": "*"
+            }
+        },
+        "node_modules/@jackmacwindows/lua-types": {
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@jackmacwindows/lua-types/-/lua-types-2.13.2.tgz",
+            "integrity": "sha512-XoqHmgtG1SLWzmMx8wQc0sJtPmrzjCFbiwNiBIZE7HOEXWdJi7NDKVlE1nl9A5745Yb5jIkfz2deOzMtHiHVcQ==",
+            "license": "MIT"
+        },
+        "node_modules/@siredvin/api-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/api-types/-/api-types-1.1.0.tgz",
+            "integrity": "sha512-jsyXqMMW9XIjYzRb4FBpbH5AnCr+QORwRzFU00Ail1pf+7qEvRepEUy6ybh0O3h/4jLlikjFfDGUkMCF18imRg==",
+            "license": "MIT"
+        },
+        "node_modules/@siredvin/cc-events": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/cc-events/-/cc-events-0.2.0.tgz",
+            "integrity": "sha512-wUzRMOer28Kx5agvsQIxYG8oCKgn+in1HwfcWMS8yO9tUqpI09PdGAJaQ0BzXP39oH1d2c/imLpPZHDihsg5pQ==",
+            "license": "MIT"
+        },
+        "node_modules/@siredvin/cc-types": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/cc-types/-/cc-types-1.1.0.tgz",
+            "integrity": "sha512-f2FsQDBep0cxxRnOcL8HSlF9yMbFvSHOXJY1aIIN7JFcQzzVBT4TNTQ01kTPf8hG2dRjgIM74sbzu2dB/3gLkQ==",
+            "license": "MIT"
+        },
+        "node_modules/@siredvin/craftos-types": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/craftos-types/-/craftos-types-1.2.0.tgz",
+            "integrity": "sha512-7QJsHifAXkzAT/BTMRzIKXXsfk8rYCV69J47yo4a+0e/iQh1T7YMoSRGZde/5tBcgRIM5bnZb92l+hjKa63aDw==",
+            "license": "MIT"
+        },
+        "node_modules/@siredvin/typed-peripheral-api": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/typed-peripheral-api/-/typed-peripheral-api-0.1.0.tgz",
+            "integrity": "sha512-Jd2oHeJ/kfJ3u2E+T1i36SoPod6UZZulB4Q0OOeH6oGkygpcGn6ssfVuTv/vRhWof84FJK2EnSd1dOrAa2ZAiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jackmacwindows/lua-types": "^2.13.1",
+                "@siredvin/api-types": "1.1.0",
+                "@siredvin/cc-types": "1.1.0",
+                "@siredvin/craftos-types": "1.2.0",
+                "@siredvin/typed-peripheral-base": "0.4.0"
+            }
+        },
+        "node_modules/@siredvin/typed-peripheral-base": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@siredvin/typed-peripheral-base/-/typed-peripheral-base-0.4.0.tgz",
+            "integrity": "sha512-/QwXoEViQi2/T6zMDAVaqIyxhtNYxbK12y47VxQ9J7fTBcJBpI06rEKl2NLgb9n1eUvsHak5IcitR3Pyu2/zsA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jackmacwindows/lua-types": "^2.13.1",
+                "@siredvin/api-types": "1.1.0",
+                "@siredvin/cc-types": "1.1.0",
+                "@siredvin/craftos-types": "1.2.0"
+            }
+        },
+        "node_modules/@typescript-to-lua/language-extensions": {
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/@typescript-to-lua/language-extensions/-/language-extensions-1.19.0.tgz",
+            "integrity": "sha512-Os5wOKwviTD4LeqI29N0btYOjokSJ97iCf45EOjIABlb5IwNQy7AE/AqZJobRw3ywHH8+KzJUMkEirWPzh2tUA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
+            "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-to-lua": {
+            "version": "1.33.2",
+            "resolved": "https://registry.npmjs.org/typescript-to-lua/-/typescript-to-lua-1.33.2.tgz",
+            "integrity": "sha512-A/o3JgPuKDn3f5nPOM8GiL1Eo5Ngw+wKGe0OxtWuwqU099ZKccpi9JG4Y3WQRHPpPkPmjD/eEQFo4UAehxO8DQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-to-lua/language-extensions": "1.19.0",
+                "enhanced-resolve": "5.8.2",
+                "picomatch": "^2.3.1",
+                "resolve": "^1.15.1",
+                "source-map": "^0.7.3"
+            },
+            "bin": {
+                "tstl": "dist/tstl.js"
+            },
+            "engines": {
+                "node": ">=16.10.0"
+            },
+            "peerDependencies": {
+                "typescript": "5.9.3"
+            }
+        }
+    }
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/package.json
+++ b/projects/typed-peripheral-unlimitedperipheralworks/package.json
@@ -1,0 +1,58 @@
+{
+    "name": "@siredvin/typed-peripheral-unlimitedperipheralworks",
+    "version": "0.4.1",
+    "description": "Typed peripheral library for UnlimitedPeripheralWorks peripherals",
+    "files": [
+        "./*.d.ts",
+        "./*.lua",
+        "./**/*.d.ts",
+        "./**/*.lua"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "author": "SirEdvin",
+    "license": "MIT",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "build": "tstl",
+        "clean": "rm -f *.lua",
+        "lint": "eslint . --ext .ts,.js",
+        "depcheck": "depcheck"
+    },
+    "dependencies": {
+        "@siredvin/cc-types": "^1.1.0",
+        "@siredvin/craftos-types": "^1.2.0",
+        "@siredvin/api-types": "^1.1.0",
+        "@jackmacwindows/lua-types": "^2.13.1",
+        "@siredvin/typed-peripheral-base": "*",
+        "@siredvin/typed-peripheral-api": "*",
+        "@siredvin/cc-events": "*"
+    },
+    "devDependencies": {
+        "typescript-to-lua": "*",
+        "typescript": "*"
+    },
+    "nx": {
+        "targets": {
+            "lint": {
+                "executor": "@nx/linter:eslint",
+                "outputs": [
+                    "{options.outputFile}"
+                ],
+                "options": {
+                    "lintFilePatterns": [
+                        "packages/typed-peripheral/**/*.{ts,tsx,js,jsx}"
+                    ]
+                }
+            },
+            "depcheck": {
+                "executor": "nx:run-commands",
+                "options": {
+                    "command": "depcheck",
+                    "cwd": "packages/typed-peripheral"
+                }
+            }
+        }
+    }
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/recipeRegistry.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/recipeRegistry.d.ts
@@ -1,0 +1,10 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { EmiRecipe } from "./integrations/emi/emiRecipePaste";
+/** @noSelf **/
+export interface RecipeRegistry extends ConfigurationAPI<object> {
+    get(recipeID: string): LuaTable<string, any> | null;
+    getEMI(recipeID: string): EmiRecipe | null;
+    getRaw(recipeID: string): LuaTable<string, any> | null;
+}
+export declare const recipeRegistryProvider: IPeripheralProvider<RecipeRegistry>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/recipeRegistry.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/recipeRegistry.ts
@@ -1,0 +1,15 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+import { EmiRecipe } from "./integrations/emi/emiRecipePaste";
+
+/** @noSelf **/
+export interface RecipeRegistry extends ConfigurationAPI<object> {
+    get(recipeID: string): LuaTable<string, any> | null;
+    getEMI(recipeID: string): EmiRecipe | null;
+    getRaw(recipeID: string): LuaTable<string, any> | null;
+}
+
+export const recipeRegistryProvider = new IPeripheralProvider<RecipeRegistry>(
+    "recipe_registry",
+    () => null
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/statueWorkbench.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/statueWorkbench.d.ts
@@ -1,0 +1,28 @@
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface StatueWorkbench extends IPeripheral {
+    isPresent(): Boolean;
+    setStatueName(name: string): any;
+    getStatueName(): string;
+    setAuthor(author: string): any;
+    getAuthor(): string;
+    setLightLevel(level: number): any;
+    getLightLevel(): number;
+    setCubes(cubes: Array<Cube>): any;
+    getCubes(): Array<Cube>;
+    reset(): any;
+}
+/** @noSelf **/
+export declare class DummyStatueWorkbench implements StatueWorkbench {
+    isPresent(): Boolean;
+    setStatueName(name: string): void;
+    getStatueName(): string;
+    setAuthor(author: string): void;
+    getAuthor(): string;
+    setLightLevel(level: number): void;
+    getLightLevel(): number;
+    setCubes(cubes: Cube[]): void;
+    getCubes(): Cube[];
+    reset(): void;
+}
+export declare const statueWorkbenchProvider: IPeripheralProvider<StatueWorkbench>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/statueWorkbench.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/statueWorkbench.ts
@@ -1,0 +1,62 @@
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+let DUMMY_NAME = "";
+let DUMMY_AUTHOR = "";
+let DUMMY_LIGHT_LEVEL = 0;
+let DUMMY_CUBES = [];
+
+/** @noSelf **/
+export interface StatueWorkbench extends IPeripheral {
+    isPresent(): Boolean;
+    setStatueName(name: string);
+    getStatueName(): string;
+    setAuthor(author: string);
+    getAuthor(): string;
+    setLightLevel(level: number);
+    getLightLevel(): number;
+    setCubes(cubes: Array<Cube>);
+    getCubes(): Array<Cube>;
+    reset();
+}
+
+/** @noSelf **/
+export class DummyStatueWorkbench implements StatueWorkbench {
+    isPresent(): Boolean {
+        return true;
+    }
+    setStatueName(name: string) {
+        DUMMY_NAME = name;
+    }
+    getStatueName(): string {
+        return DUMMY_NAME;
+    }
+    setAuthor(author: string) {
+        DUMMY_AUTHOR = author;
+    }
+    getAuthor(): string {
+        return DUMMY_AUTHOR;
+    }
+    setLightLevel(level: number) {
+        DUMMY_LIGHT_LEVEL = level;
+    }
+    getLightLevel(): number {
+        return DUMMY_LIGHT_LEVEL;
+    }
+    setCubes(cubes: Cube[]) {
+        DUMMY_CUBES = cubes;
+    }
+    getCubes(): Cube[] {
+        return DUMMY_CUBES;
+    }
+    reset() {
+        DUMMY_AUTHOR = "";
+        DUMMY_CUBES = [];
+        DUMMY_NAME = "";
+        DUMMY_LIGHT_LEVEL = 0;
+    }
+}
+
+export const statueWorkbenchProvider = new IPeripheralProvider<StatueWorkbench>(
+    "statue_workbench",
+    () => new DummyStatueWorkbench()
+);

--- a/projects/typed-peripheral-unlimitedperipheralworks/tsconfig.json
+++ b/projects/typed-peripheral-unlimitedperipheralworks/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://raw.githubusercontent.com/MCJack123/TypeScriptToLua/master/tsconfig-schema.json",
+    "compilerOptions": {
+        "target": "ESNext",
+        "lib": ["ESNext"],
+        "moduleResolution": "node",
+        "strict": false,
+        "declaration": true,
+        "types": [
+            "@jackmacwindows/lua-types/cc",
+            "@siredvin/craftos-types",
+            "@siredvin/cc-types",
+            "@siredvin/api-types"
+        ]
+    },
+    "tstl": {
+        "luaTarget": "5.1",
+        "luaLibImport": "require-minimal",
+        "buildMode": "library"
+    },
+    "include": ["./*.ts", "./**/*.ts"]
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/universalScanner.d.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/universalScanner.d.ts
@@ -1,0 +1,8 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { OperationApi } from "@siredvin/typed-peripheral-api/operations";
+import { ScanApi } from "@siredvin/typed-peripheral-api/scan";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+/** @noSelf **/
+export interface UniversalScanner extends ScanApi, OperationApi, ConfigurationAPI<object> {
+}
+export declare const universalScannerProvider: IPeripheralProvider<UniversalScanner>;

--- a/projects/typed-peripheral-unlimitedperipheralworks/universalScanner.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/universalScanner.ts
@@ -1,0 +1,13 @@
+import { ConfigurationAPI } from "@siredvin/typed-peripheral-api/configuration";
+import { OperationApi } from "@siredvin/typed-peripheral-api/operations";
+import { ScanApi } from "@siredvin/typed-peripheral-api/scan";
+import { IPeripheralProvider } from "@siredvin/typed-peripheral-base";
+
+/** @noSelf **/
+export interface UniversalScanner
+    extends ScanApi,
+        OperationApi,
+        ConfigurationAPI<object> {}
+
+export const universalScannerProvider =
+    new IPeripheralProvider<UniversalScanner>("universal_scanner", () => null);

--- a/projects/typescript-tests/package-lock.json
+++ b/projects/typescript-tests/package-lock.json
@@ -7,7 +7,8 @@
       "name": "peripheralworks-gametests",
       "dependencies": {
         "@siredvin/cc-utils": "0.1.0",
-        "@siredvin/soteria": "0.1.0"
+        "@siredvin/soteria": "0.1.0",
+        "@siredvin/typed-peripheral-unlimitedperipheralworks": "file:../typed-peripheral-unlimitedperipheralworks"
       },
       "devDependencies": {
         "@jackmacwindows/lua-types": "2.13.1",
@@ -16,6 +17,24 @@
         "@siredvin/craftos-types": "1.2.0",
         "typescript": "5.7.2",
         "typescript-to-lua": "1.29.1"
+      }
+    },
+    "../typed-peripheral-unlimitedperipheralworks": {
+      "name": "@siredvin/typed-peripheral-unlimitedperipheralworks",
+      "version": "0.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "@jackmacwindows/lua-types": "^2.13.1",
+        "@siredvin/api-types": "^1.1.0",
+        "@siredvin/cc-events": "*",
+        "@siredvin/cc-types": "^1.1.0",
+        "@siredvin/craftos-types": "^1.2.0",
+        "@siredvin/typed-peripheral-api": "*",
+        "@siredvin/typed-peripheral-base": "*"
+      },
+      "devDependencies": {
+        "typescript": "*",
+        "typescript-to-lua": "*"
       }
     },
     "node_modules/@jackmacwindows/lua-types": {
@@ -81,6 +100,10 @@
         "@siredvin/cc-types": "1.1.0",
         "@siredvin/craftos-types": "1.2.0"
       }
+    },
+    "node_modules/@siredvin/typed-peripheral-unlimitedperipheralworks": {
+      "resolved": "../typed-peripheral-unlimitedperipheralworks",
+      "link": true
     },
     "node_modules/@typescript-to-lua/language-extensions": {
       "version": "1.19.0",

--- a/projects/typescript-tests/package.json
+++ b/projects/typescript-tests/package.json
@@ -6,7 +6,8 @@
   },
   "dependencies": {
     "@siredvin/cc-utils": "0.1.0",
-    "@siredvin/soteria": "0.1.0"
+    "@siredvin/soteria": "0.1.0",
+    "@siredvin/typed-peripheral-unlimitedperipheralworks": "file:../typed-peripheral-unlimitedperipheralworks"
   },
   "devDependencies": {
     "@jackmacwindows/lua-types": "2.13.1",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ rootProject.name = "UnlimitedPeripheralWorks $minecraftVersion"
 include(":core")
 include(":forge")
 include(":fabric")
+include(":typed-peripheral-unlimitedperipheralworks")
 include(":typescript-tests")
 
 


### PR DESCRIPTION
## Summary
- add `typed-peripheral-unlimitedperipheralworks` unchanged as a Gradle-managed TypeScript subproject
- compile and consume the local package from TypeScript GameTests
- include typed-package assembly in the root build

## Testing
- `./gradlew :typed-peripheral-unlimitedperipheralworks:assemble :typescript-tests:compileTestLua --no-daemon`
- `./gradlew build --no-daemon`
- `npm pack --dry-run --json`