### PR TITLE
Fix reality anchor light passability

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/block/FlexibleRealityAnchor.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/block/FlexibleRealityAnchor.kt
@@ -68,7 +68,7 @@ class FlexibleRealityAnchor :
         builder.add(INVISIBLE)
     }
 
-    override fun getLightBlock(blockState: BlockState, blockGetter: BlockGetter, blockPos: BlockPos): Int = if (blockState.getValue(LIGHT_PASSABLE) || !blockState.getValue(CONFIGURED)) 0 else LightEngine.MAX_LEVEL
+    override fun getLightBlock(blockState: BlockState, blockGetter: BlockGetter, blockPos: BlockPos): Int = if (!blockState.getValue(CONFIGURED) || blockState.getValue(LIGHT_PASSABLE) && blockState.getValue(SKY_LIGHT_PASSABLE)) 0 else LightEngine.MAX_LEVEL
 
     override fun createItemStack(): ItemStack = ItemStack(Blocks.FLEXIBLE_REALITY_ANCHOR.get().asItem())
 
@@ -91,7 +91,7 @@ class FlexibleRealityAnchor :
         return if (blockState.getValue(INVISIBLE)) RenderShape.INVISIBLE else super.getRenderShape(blockState)
     }
 
-    override fun useShapeForLightOcclusion(state: BlockState): Boolean = true
+    override fun useShapeForLightOcclusion(state: BlockState): Boolean = !state.getValue(LIGHT_PASSABLE) && state.getValue(CONFIGURED)
 
     override fun getVisualShape(
         state: BlockState,

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/block/FlexibleRealityAnchor.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/block/FlexibleRealityAnchor.kt
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.level.block.state.StateDefinition
 import net.minecraft.world.level.block.state.properties.BooleanProperty
 import net.minecraft.world.level.block.state.properties.Property
+import net.minecraft.world.level.lighting.LightEngine
 import net.minecraft.world.level.material.MapColor
 import net.minecraft.world.phys.shapes.CollisionContext
 import net.minecraft.world.phys.shapes.EntityCollisionContext
@@ -67,10 +68,7 @@ class FlexibleRealityAnchor :
         builder.add(INVISIBLE)
     }
 
-    override fun getLightBlock(blockState: BlockState, blockGetter: BlockGetter, blockPos: BlockPos): Int {
-        val blockEntity = blockGetter.getBlockEntity(blockPos)
-        return if (blockEntity is FlexibleRealityAnchorBlockEntity) blockEntity.lightLevel else 0
-    }
+    override fun getLightBlock(blockState: BlockState, blockGetter: BlockGetter, blockPos: BlockPos): Int = if (blockState.getValue(LIGHT_PASSABLE) || !blockState.getValue(CONFIGURED)) 0 else LightEngine.MAX_LEVEL
 
     override fun createItemStack(): ItemStack = ItemStack(Blocks.FLEXIBLE_REALITY_ANCHOR.get().asItem())
 

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -1,13 +1,14 @@
 package site.siredvin.peripheralworks.testmod
 
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
 import net.minecraft.gametest.framework.GameTest
 import net.minecraft.gametest.framework.GameTestHelper
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.ItemStack
-import net.minecraft.world.level.lighting.LightEngine
+import net.minecraft.world.level.LightLayer
 import site.siredvin.peripheralworks.client.configurator.NetworkManagerGroupHierarchy
 import site.siredvin.peripheralworks.common.block.FlexibleRealityAnchor
 import site.siredvin.peripheralworks.common.blockentity.NetworkManagerBlockEntity
@@ -24,30 +25,51 @@ import site.siredvin.peripheralworks.subsystem.configurator.RemoteObserverMode
 import site.siredvin.peripheralworks.subsystem.configurator.TextStyle
 import site.siredvin.testiarium.api.TestGroup
 import site.siredvin.testiarium.cct.thenLua
+import net.minecraft.world.level.block.Blocks as MinecraftBlocks
 
 @TestGroup("peripheralworks")
 class PeripheralWorksGameTests {
     @GameTest(template = "empty")
     fun realityAnchorLightPassability(helper: GameTestHelper) {
-        val pos = BlockPos(1, 1, 1)
-        val absolutePos = helper.absolutePos(pos)
+        val below = BlockPos(2, 1, 2)
+        val anchor = below.above()
+        val source = anchor.above()
+        helper.setBlock(below.below(), MinecraftBlocks.STONE)
+        Direction.Plane.HORIZONTAL.forEach {
+            helper.setBlock(below.relative(it), MinecraftBlocks.STONE)
+            helper.setBlock(anchor.relative(it), MinecraftBlocks.STONE)
+        }
         val configured = Blocks.FLEXIBLE_REALITY_ANCHOR.get().defaultBlockState()
             .setValue(FlexibleRealityAnchor.CONFIGURED, true)
+        helper.setBlock(anchor, configured)
 
-        helper.setBlock(pos, configured)
-        check(configured.getLightBlock(helper.level, absolutePos) == LightEngine.MAX_LEVEL)
-        check(!configured.propagatesSkylightDown(helper.level, absolutePos))
-
-        val lightPassable = configured.setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
-        helper.setBlock(pos, lightPassable)
-        check(lightPassable.getLightBlock(helper.level, absolutePos) == 0)
-        check(!lightPassable.propagatesSkylightDown(helper.level, absolutePos))
-
-        val skylightPassable = configured.setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true)
-        helper.setBlock(pos, skylightPassable)
-        check(skylightPassable.getLightBlock(helper.level, absolutePos) == LightEngine.MAX_LEVEL)
-        check(skylightPassable.propagatesSkylightDown(helper.level, absolutePos))
-        helper.succeed()
+        helper.runAtTickTime(10) {
+            helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, helper.absolutePos(below)) == 0, "Anchor should block skylight")
+            helper.setBlock(
+                anchor,
+                configured
+                    .setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
+                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true),
+            )
+        }
+        helper.runAtTickTime(20) {
+            helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, helper.absolutePos(below)) > 0, "Anchor should pass skylight")
+            helper.setBlock(source, MinecraftBlocks.GLOWSTONE)
+            helper.setBlock(anchor, configured)
+        }
+        helper.runAtTickTime(30) {
+            helper.assertTrue(helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below)) == 0, "Anchor should block light")
+            helper.setBlock(
+                anchor,
+                configured
+                    .setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
+                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true),
+            )
+        }
+        helper.runAtTickTime(40) {
+            helper.assertTrue(helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below)) > 0, "Anchor should pass light")
+            helper.succeed()
+        }
     }
 
     @GameTest(template = "empty")

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -81,9 +81,14 @@ class PeripheralWorksGameTests {
             below
         }
         positions.values.forEach { below ->
+            val source = helper.absolutePos(below.above(2))
+            val surface = helper.level.getHeight(net.minecraft.world.level.levelgen.Heightmap.Types.WORLD_SURFACE, source.x, source.z)
+            for (y in source.y..surface) {
+                helper.level.setBlock(BlockPos(source.x, y, source.z), MinecraftBlocks.AIR.defaultBlockState(), net.minecraft.world.level.block.Block.UPDATE_ALL)
+            }
             helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below))
             helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below.above()))
-            helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below.above(2)))
+            helper.level.chunkSource.lightEngine.checkBlock(source)
         }
         var nightBrightness = 0
         helper.setNight()

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -29,47 +29,74 @@ import net.minecraft.world.level.block.Blocks as MinecraftBlocks
 
 @TestGroup("peripheralworks")
 class PeripheralWorksGameTests {
-    @GameTest(template = "empty")
-    fun realityAnchorLightPassability(helper: GameTestHelper) {
-        val below = BlockPos(2, 1, 2)
-        val anchor = below.above()
-        val source = anchor.above()
-        helper.setBlock(below.below(), MinecraftBlocks.STONE)
-        Direction.Plane.HORIZONTAL.forEach {
-            helper.setBlock(below.relative(it), MinecraftBlocks.STONE)
-            helper.setBlock(anchor.relative(it), MinecraftBlocks.STONE)
+    @GameTest(template = "light_test")
+    fun realityAnchorBlockLightPassability(helper: GameTestHelper) {
+        val cases = listOf(false to false, true to false, false to true, true to true)
+        val positions = cases.mapIndexed { index, (passable, sourcePresent) ->
+            val below = BlockPos(1 + index * 3, 1, 1)
+            val anchor = below.above()
+            helper.setBlock(below.below(), MinecraftBlocks.STONE)
+            Direction.Plane.HORIZONTAL.forEach {
+                helper.setBlock(below.relative(it), MinecraftBlocks.STONE)
+                helper.setBlock(anchor.relative(it), MinecraftBlocks.STONE)
+            }
+            helper.setBlock(anchor.above(), if (sourcePresent) MinecraftBlocks.GLOWSTONE else MinecraftBlocks.STONE)
+            helper.setBlock(
+                anchor,
+                Blocks.FLEXIBLE_REALITY_ANCHOR.get().defaultBlockState()
+                    .setValue(FlexibleRealityAnchor.CONFIGURED, true)
+                    .setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, passable)
+                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true),
+            )
+            Triple(below, passable && sourcePresent, "passable=$passable, source=$sourcePresent")
         }
-        val configured = Blocks.FLEXIBLE_REALITY_ANCHOR.get().defaultBlockState()
-            .setValue(FlexibleRealityAnchor.CONFIGURED, true)
-        helper.setBlock(anchor, configured)
 
-        helper.runAtTickTime(10) {
-            helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, helper.absolutePos(below)) == 0, "Anchor should block skylight")
+        helper.succeedWhen {
+            positions.forEach { (below, shouldBeLit, description) ->
+                val brightness = helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below))
+                val anchorBrightness = helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below.above()))
+                val sourceBrightness = helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below.above(2)))
+                helper.assertTrue(if (shouldBeLit) brightness > 0 else brightness == 0, "Unexpected block light levels below=$brightness, anchor=$anchorBrightness, source=$sourceBrightness ($description)")
+            }
+        }
+    }
+
+    @GameTest(template = "light_test")
+    fun realityAnchorSkylightPassability(helper: GameTestHelper) {
+        val positions = listOf(false, true).associateWith { passable ->
+            val below = BlockPos(if (passable) 4 else 1, 1, 1)
+            val anchor = below.above()
+            helper.setBlock(below.below(), MinecraftBlocks.STONE)
+            Direction.Plane.HORIZONTAL.forEach {
+                helper.setBlock(below.relative(it), MinecraftBlocks.STONE)
+                helper.setBlock(anchor.relative(it), MinecraftBlocks.STONE)
+            }
             helper.setBlock(
                 anchor,
-                configured
+                Blocks.FLEXIBLE_REALITY_ANCHOR.get().defaultBlockState()
+                    .setValue(FlexibleRealityAnchor.CONFIGURED, true)
                     .setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
-                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true),
+                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, passable),
             )
+            below
         }
-        helper.runAtTickTime(20) {
-            helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, helper.absolutePos(below)) > 0, "Anchor should pass skylight")
-            helper.setBlock(source, MinecraftBlocks.GLOWSTONE)
-            helper.setBlock(anchor, configured)
-        }
-        helper.runAtTickTime(30) {
-            helper.assertTrue(helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below)) == 0, "Anchor should block light")
-            helper.setBlock(
-                anchor,
-                configured
-                    .setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
-                    .setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true),
-            )
-        }
-        helper.runAtTickTime(40) {
-            helper.assertTrue(helper.level.getBrightness(LightLayer.BLOCK, helper.absolutePos(below)) > 0, "Anchor should pass light")
-            helper.succeed()
-        }
+        var nightBrightness = 0
+        helper.setNight()
+        helper.startSequence()
+            .thenWaitUntil {
+                helper.assertTrue(helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(false))) == 0, "Anchor should block skylight at night")
+                nightBrightness = helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(true)))
+                helper.assertTrue(nightBrightness > 0, "Anchor should pass skylight at night")
+            }
+            .thenExecute { helper.setDayTime(6000) }
+            .thenWaitUntil {
+                helper.assertTrue(helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(false))) == 0, "Anchor should block skylight during the day")
+                val passablePos = helper.absolutePos(positions.getValue(true))
+                val dayBrightness = helper.level.getMaxLocalRawBrightness(passablePos)
+                val rawBrightness = helper.level.getBrightness(LightLayer.SKY, passablePos)
+                helper.assertTrue(dayBrightness > nightBrightness, "Daytime skylight should be brighter than nighttime skylight (day=$dayBrightness, night=$nightBrightness, raw=$rawBrightness)")
+            }
+            .thenSucceed()
     }
 
     @GameTest(template = "empty")

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -7,7 +7,9 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.level.lighting.LightEngine
 import site.siredvin.peripheralworks.client.configurator.NetworkManagerGroupHierarchy
+import site.siredvin.peripheralworks.common.block.FlexibleRealityAnchor
 import site.siredvin.peripheralworks.common.blockentity.NetworkManagerBlockEntity
 import site.siredvin.peripheralworks.common.blockentity.PeripheralProxyBlockEntity
 import site.siredvin.peripheralworks.common.blockentity.RemoteObserverBlockEntity
@@ -25,6 +27,29 @@ import site.siredvin.testiarium.cct.thenLua
 
 @TestGroup("peripheralworks")
 class PeripheralWorksGameTests {
+    @GameTest(template = "empty")
+    fun realityAnchorLightPassability(helper: GameTestHelper) {
+        val pos = BlockPos(1, 1, 1)
+        val absolutePos = helper.absolutePos(pos)
+        val configured = Blocks.FLEXIBLE_REALITY_ANCHOR.get().defaultBlockState()
+            .setValue(FlexibleRealityAnchor.CONFIGURED, true)
+
+        helper.setBlock(pos, configured)
+        check(configured.getLightBlock(helper.level, absolutePos) == LightEngine.MAX_LEVEL)
+        check(!configured.propagatesSkylightDown(helper.level, absolutePos))
+
+        val lightPassable = configured.setValue(FlexibleRealityAnchor.LIGHT_PASSABLE, true)
+        helper.setBlock(pos, lightPassable)
+        check(lightPassable.getLightBlock(helper.level, absolutePos) == 0)
+        check(!lightPassable.propagatesSkylightDown(helper.level, absolutePos))
+
+        val skylightPassable = configured.setValue(FlexibleRealityAnchor.SKY_LIGHT_PASSABLE, true)
+        helper.setBlock(pos, skylightPassable)
+        check(skylightPassable.getLightBlock(helper.level, absolutePos) == LightEngine.MAX_LEVEL)
+        check(skylightPassable.propagatesSkylightDown(helper.level, absolutePos))
+        helper.succeed()
+    }
+
     @GameTest(template = "empty")
     fun peripheralProxyRenderSettingsPersistAndFallback(helper: GameTestHelper) {
         val firstPos = BlockPos(1, 1, 1)

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -80,6 +80,11 @@ class PeripheralWorksGameTests {
             )
             below
         }
+        positions.values.forEach { below ->
+            helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below))
+            helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below.above()))
+            helper.level.chunkSource.lightEngine.checkBlock(helper.absolutePos(below.above(2)))
+        }
         var nightBrightness = 0
         helper.setNight()
         helper.startSequence()

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/PeripheralWorksGameTests.kt
@@ -61,7 +61,7 @@ class PeripheralWorksGameTests {
         }
     }
 
-    @GameTest(template = "light_test")
+    @GameTest(template = "light_test", timeoutTicks = 1200)
     fun realityAnchorSkylightPassability(helper: GameTestHelper) {
         val positions = listOf(false, true).associateWith { passable ->
             val below = BlockPos(if (passable) 4 else 1, 1, 1)
@@ -84,16 +84,21 @@ class PeripheralWorksGameTests {
         helper.setNight()
         helper.startSequence()
             .thenWaitUntil {
-                helper.assertTrue(helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(false))) == 0, "Anchor should block skylight at night")
-                nightBrightness = helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(true)))
+                val blockedPos = helper.absolutePos(positions.getValue(false))
+                val passablePos = helper.absolutePos(positions.getValue(true))
+                helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, blockedPos) == 0, "Anchor should block skylight at night")
+                helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, passablePos) > 0, "Anchor should pass skylight at night")
+                nightBrightness = helper.level.getMaxLocalRawBrightness(passablePos)
                 helper.assertTrue(nightBrightness > 0, "Anchor should pass skylight at night")
             }
             .thenExecute { helper.setDayTime(6000) }
             .thenWaitUntil {
-                helper.assertTrue(helper.level.getMaxLocalRawBrightness(helper.absolutePos(positions.getValue(false))) == 0, "Anchor should block skylight during the day")
+                val blockedPos = helper.absolutePos(positions.getValue(false))
                 val passablePos = helper.absolutePos(positions.getValue(true))
+                helper.assertTrue(helper.level.getBrightness(LightLayer.SKY, blockedPos) == 0, "Anchor should block skylight during the day")
                 val dayBrightness = helper.level.getMaxLocalRawBrightness(passablePos)
                 val rawBrightness = helper.level.getBrightness(LightLayer.SKY, passablePos)
+                helper.assertTrue(rawBrightness > 0, "Anchor should pass skylight during the day")
                 helper.assertTrue(dayBrightness > nightBrightness, "Daytime skylight should be brighter than nighttime skylight (day=$dayBrightness, night=$nightBrightness, raw=$rawBrightness)")
             }
             .thenSucceed()

--- a/projects/core/src/testMod/resources/gameteststructures/light_test.snbt
+++ b/projects/core/src/testMod/resources/gameteststructures/light_test.snbt
@@ -1,0 +1,1 @@
+{size:[12,4,3],entities:[],data:[],palette:[],DataVersion:3465}


### PR DESCRIPTION
## Summary
- make configured reality anchors use maximum light opacity when light passability is disabled
- add a world-level GameTest with skylight and glowstone above an enclosed anchor
- verify both blocked and passable configurations against the block below

## Testing
- `timeout --foreground 20m xvfb-run -a ./gradlew gameTest --no-daemon -PminimalTestEnvironment`
- `timeout --foreground 10m ./gradlew build --no-daemon`

Closes #54