### PR TITLE
fix: correct Fabric overlay text orientation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ loom = "1.17.11"
 mixinGradle = "0.7.+"
 forgegradle = "6.+"
 # Core mod dependencies
-cc-tweaked = "1.113.0"
+cc-tweaked = "1.113.1"
 broccolium = "1.4.6"
 tweakium = "1.4.9"
 peripheralium = "1.4.6"

--- a/projects/fabric/src/main/kotlin/site/siredvin/peripheralworks/FabricPeripheralWorksClient.kt
+++ b/projects/fabric/src/main/kotlin/site/siredvin/peripheralworks/FabricPeripheralWorksClient.kt
@@ -9,6 +9,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelResolver
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents
+import net.minecraft.client.Minecraft
 import net.minecraft.client.renderer.RenderType
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers
 import net.minecraft.resources.ResourceLocation
@@ -51,11 +52,10 @@ object FabricPeripheralWorksClient : ClientModInitializer {
             FabricComputerCraftAPIClient.registerTurtleUpgradeModeller(upgrade as UpgradeType<ITurtleUpgrade>, modeller)
         }
 
-        WorldRenderEvents.AFTER_ENTITIES.register {
+        WorldRenderEvents.LAST.register {
             val matrix = it.matrixStack()
-            val consumers = it.consumers()
-            if (matrix != null && consumers != null) {
-                ConfigurationModeRenderRegistry.render(matrix, consumers, it.world(), it.camera())
+            if (matrix != null) {
+                ConfigurationModeRenderRegistry.render(matrix, Minecraft.getInstance().renderBuffers().bufferSource(), it.world(), it.camera())
             }
         }
 


### PR DESCRIPTION
## Summary
- render Fabric configurator overlays from `WorldRenderEvents.LAST`
- restore the camera-view render state expected by direct text rendering
- align CC:Tweaked 1.113.1 with Tweakium 1.4.9 runtime requirements
- keep the shared billboard transform and NeoForge render path unchanged

## Root cause
Fabric 1.21 moved the overlay hook from the late world-render event to `AFTER_ENTITIES`. That event is intended for appending to entity consumers and does not establish the camera-view state used by this renderer, causing its explicit billboard rotation to produce upside-down text.

The earlier Tweakium 1.4.9 upgrade also retained CC:Tweaked 1.113.0 even though Tweakium requires 1.113.1 or newer.

## Verification
- `./gradlew :fabric:compileKotlin --no-daemon -Pkotlin.incremental=false`
- `./gradlew build --no-daemon -Pkotlin.incremental=false`
- `timeout --foreground 20m xvfb-run -a ./gradlew gameTest --no-daemon -PminimalTestEnvironment -Pkotlin.incremental=false`