### PR TITLE
Fix empty display pedestal serialization

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/DisplayPedestalBlockEntity.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/blockentity/DisplayPedestalBlockEntity.kt
@@ -66,7 +66,7 @@ class DisplayPedestalBlockEntity(blockPos: BlockPos, blockState: BlockState, blo
     }
 
     override fun saveInternalData(data: CompoundTag): CompoundTag {
-        data.put(STORED_ITEM_STACK_TAG, _storedStack.save(PlatformToolkit.get().registries!!))
+        data.put(STORED_ITEM_STACK_TAG, _storedStack.saveOptional(PlatformToolkit.get().registries!!))
         data.putBoolean(RENDER_ITEM_TAG, _renderItem)
         data.putBoolean(RENDER_LABEL_TAG, _renderLabel)
         return data

--- a/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/NetworkManagerClientGameTests.kt
+++ b/projects/core/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/NetworkManagerClientGameTests.kt
@@ -21,6 +21,7 @@ import site.siredvin.peripheralworks.client.configurator.ConfiguratorTargetHisto
 import site.siredvin.peripheralworks.client.configurator.NetworkManagerColorPickerScreen
 import site.siredvin.peripheralworks.client.configurator.NetworkManagerScreen
 import site.siredvin.peripheralworks.client.configurator.TargetRenderSettingsScreen
+import site.siredvin.peripheralworks.common.blockentity.DisplayPedestalBlockEntity
 import site.siredvin.peripheralworks.common.blockentity.NetworkManagerBlockEntity
 import site.siredvin.peripheralworks.common.blockentity.PeripheralProxyBlockEntity
 import site.siredvin.peripheralworks.common.blockentity.RemoteObserverBlockEntity
@@ -36,11 +37,37 @@ import site.siredvin.peripheralworks.subsystem.configurator.TextStyle
 import site.siredvin.testiarium.api.ClientGameTest
 import site.siredvin.testiarium.api.TestGroup
 import site.siredvin.testiarium.fixture.client.ClientTestHelper
+import site.siredvin.testiarium.fixture.client.positionAt
 import site.siredvin.testiarium.fixture.client.thenOnClient
+import site.siredvin.testiarium.fixture.client.thenScreenshot
 import java.io.File
+import net.minecraft.world.item.Items as MinecraftItems
 
 @TestGroup("network-manager-client")
 class NetworkManagerClientGameTests {
+    @ClientGameTest(template = "empty", timeoutTicks = 200)
+    @TestGroup("display-pedestal-client")
+    fun rendersEmptyAndConfiguredDisplayPedestal(helper: GameTestHelper) {
+        val pedestalPos = BlockPos(1, 1, 1)
+        helper.startSequence()
+            .thenExecute {
+                listOf("display-pedestal-empty.png", "display-pedestal-configured.png").forEach {
+                    screenshotFile(it).apply {
+                        parentFile.mkdirs()
+                        delete()
+                    }
+                }
+                helper.setBlock(pedestalPos, Blocks.DISPLAY_PEDESTAL.get())
+                helper.positionAt(BlockPos(1, 2, 4), 180f, 15f)
+            }
+            .thenScreenshot("display-pedestal-empty")
+            .thenExecute {
+                (helper.getBlockEntity(pedestalPos) as DisplayPedestalBlockEntity).storedStack = ItemStack(MinecraftItems.DIAMOND, 16)
+            }
+            .thenScreenshot("display-pedestal-configured")
+            .thenSucceed()
+    }
+
     @ClientGameTest(template = "empty", timeoutTicks = 600)
     fun managesDetachedConfiguratorTargetsAndPreservesAttachedUse(helper: GameTestHelper) {
         val proxyPos = BlockPos(1, 1, 1)

--- a/projects/fabric/build.gradle.kts
+++ b/projects/fabric/build.gradle.kts
@@ -98,7 +98,7 @@ loom {
             source(testMod)
             property("fabric-api.gametest", "true")
             property("testiarium.client", "true")
-            property("testiarium.tags", "network-manager-client")
+            property("testiarium.tags", providers.gradleProperty("testiariumClientTags").orElse("network-manager-client,display-pedestal-client").get())
             property("testiarium.structures", project(":core").layout.buildDirectory.dir("resources/testMod/gameteststructures").get().asFile.absolutePath)
             property("testiarium.gametest-report", layout.buildDirectory.file("test-results/network-manager-client-gametest.xml").get().asFile.absolutePath)
             property("testiarium.screenshots", layout.buildDirectory.dir("screenshots/network-manager-client").get().asFile.absolutePath)

--- a/projects/forge/build.gradle.kts
+++ b/projects/forge/build.gradle.kts
@@ -222,7 +222,7 @@ neoForge {
             gameDirectory = file("run/network-manager-client-gametest")
             systemProperty("neoforge.enabledGameTestNamespaces", "peripheralworks_testmod")
             systemProperty("testiarium.client", "true")
-            systemProperty("testiarium.tags", "network-manager-client")
+            systemProperty("testiarium.tags", providers.gradleProperty("testiariumClientTags").orElse("network-manager-client,display-pedestal-client").get())
             systemProperty("testiarium.structures", project.project(":core").layout.buildDirectory.dir("resources/testMod/gameteststructures").get().asFile.absolutePath)
             systemProperty("testiarium.gametest-report", layout.buildDirectory.file("test-results/network-manager-client-gametest.xml").get().asFile.absolutePath)
             systemProperty("testiarium.screenshots", layout.buildDirectory.dir("screenshots/network-manager-client").get().asFile.absolutePath)


### PR DESCRIPTION
## Summary
- serialize empty display pedestal stacks with Minecraft optional stack encoding
- add a client GameTest with empty and configured pedestal screenshots
- allow isolated client-test tag selection on both loaders

## Testing
- `timeout --foreground 20m xvfb-run -a ./gradlew gameTest --no-daemon -PminimalTestEnvironment -x :typed-peripheral-unlimitedperipheralworks:compileTypeScript` (29/29 passed on Fabric and NeoForge)
- `timeout --foreground 10m xvfb-run -a ./gradlew :forge:runClientGameTest --no-daemon -PtestiariumClientTags=display-pedestal-client -x :typed-peripheral-unlimitedperipheralworks:compileTypeScript` (1/1 passed; both screenshots captured)
- `./gradlew build --no-daemon -x :typed-peripheral-unlimitedperipheralworks:compileTypeScript`

Full build remains blocked on the base branch by `AE2CraftingJob` missing from `./ae2` in `ae2CraftingMonitor.d.ts`.