### PR TITLE
Fix integration config reads before load

### DIFF
--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/ConfigHolder.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/ConfigHolder.kt
@@ -6,6 +6,9 @@ object ConfigHolder {
     private var configuredSpec: ForgeConfigSpec? = null
     private var configuredCommon: PeripheralWorksConfig.CommonConfig? = null
 
+    internal val isLoaded: Boolean
+        get() = configuredSpec?.isLoaded == true
+
     val commonSpec: ForgeConfigSpec
         get() = checkNotNull(configuredSpec) { "Peripheral Works configuration has not been initialized" }
     val commonConfig: PeripheralWorksConfig.CommonConfig

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/IntegrationConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/IntegrationConfiguration.kt
@@ -1,7 +1,10 @@
 package site.siredvin.peripheralworks.common.configuration
 
+import net.minecraftforge.common.ForgeConfigSpec
 import site.siredvin.peripheralworks.api.IForgeConfigHandler
 
 interface IntegrationConfiguration : IForgeConfigHandler {
     val modID: String
+
+    fun <T> ForgeConfigSpec.ConfigValue<T>?.getOrDefault(default: T): T = if (this == null || !ConfigHolder.isLoaded) default else get()
 }

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AE2Configuration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AE2Configuration.kt
@@ -17,16 +17,16 @@ object AE2Configuration : IntegrationConfiguration {
     private var maxItemFilterSizeConfig: ForgeConfigSpec.IntValue? = null
 
     val enableMEInterface: Boolean
-        get() = enableMeInterfaceConfig?.get() ?: true
+        get() = enableMeInterfaceConfig.getOrDefault(true)
 
     val enableStorageIntegrations: Boolean
-        get() = enableStorageIntegrationConfig?.get() ?: true
+        get() = enableStorageIntegrationConfig.getOrDefault(true)
 
     val maxSubscriptions: Int
-        get() = maxSubscriptionsConfig?.get() ?: DEFAULT_MAX_SUBSCRIPTIONS
+        get() = maxSubscriptionsConfig.getOrDefault(DEFAULT_MAX_SUBSCRIPTIONS)
 
     val maxItemFilterSize: Int
-        get() = maxItemFilterSizeConfig?.get() ?: DEFAULT_MAX_ITEM_FILTER_SIZE
+        get() = maxItemFilterSizeConfig.getOrDefault(DEFAULT_MAX_ITEM_FILTER_SIZE)
 
     override val name: String
         get() = "ae2"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AdditionalLanternsConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AdditionalLanternsConfiguration.kt
@@ -11,7 +11,7 @@ object AdditionalLanternsConfiguration : IntegrationConfiguration {
     private var enableLanternsConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableLanterns: Boolean
-        get() = enableLanternsConfig?.get() ?: true
+        get() = enableLanternsConfig.getOrDefault(true)
 
     override val name: String
         get() = "additionallanterns"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AlloyForgeryConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AlloyForgeryConfiguration.kt
@@ -11,7 +11,7 @@ object AlloyForgeryConfiguration : IntegrationConfiguration {
     private var enableAlloyForgeryConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableAlloyForgery: Boolean
-        get() = enableAlloyForgeryConfig?.get() ?: true
+        get() = enableAlloyForgeryConfig.getOrDefault(true)
 
     override val name: String
         get() = "alloy_forgery"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ArsNouveauConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ArsNouveauConfiguration.kt
@@ -15,13 +15,13 @@ object ArsNouveauConfiguration : IntegrationConfiguration {
     private var enableMobJarPluginConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableCasterTomePocketUpgrade: Boolean
-        get() = enableCasterTomePocketUpgradeConfig?.get() != false
+        get() = enableCasterTomePocketUpgradeConfig.getOrDefault(true)
 
     val enableSourceStorage: Boolean
-        get() = enableSourceStorageConfig?.get() != false
+        get() = enableSourceStorageConfig.getOrDefault(true)
 
     val enableMobJarPlugin: Boolean
-        get() = enableMobJarPluginConfig?.get() != false
+        get() = enableMobJarPluginConfig.getOrDefault(true)
 
     override fun addToConfig(builder: ForgeConfigSpec.Builder) {
         enableCasterTomePocketUpgradeConfig = builder.comment("Enables usage of caster tome as pocket computer upgrade")

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AutomobilityConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/AutomobilityConfiguration.kt
@@ -11,7 +11,7 @@ object AutomobilityConfiguration : IntegrationConfiguration {
     private var enableAutomobilityConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableAutomobile: Boolean
-        get() = enableAutomobilityConfig?.get() ?: true
+        get() = enableAutomobilityConfig.getOrDefault(true)
 
     override val name: String
         get() = "automobility"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/CreateConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/CreateConfiguration.kt
@@ -11,7 +11,7 @@ object CreateConfiguration : IntegrationConfiguration {
     private var enableCreateIntegrationConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableCreateIntegration: Boolean
-        get() = enableCreateIntegrationConfig?.get() ?: true
+        get() = enableCreateIntegrationConfig.getOrDefault(true)
 
     override val name: String
         get() = "create"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/DeepResonanceConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/DeepResonanceConfiguration.kt
@@ -13,13 +13,13 @@ object DeepResonanceConfiguration : IntegrationConfiguration {
     private var enableTankConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableResonatingCrystal: Boolean
-        get() = enableResonatingCrystalConfig?.get() ?: true
+        get() = enableResonatingCrystalConfig.getOrDefault(true)
 
     val enableGeneratorPart: Boolean
-        get() = enableGeneratorPartConfig?.get() ?: true
+        get() = enableGeneratorPartConfig.getOrDefault(true)
 
     val enableTank: Boolean
-        get() = enableTankConfig?.get() ?: true
+        get() = enableTankConfig.getOrDefault(true)
 
     override val name: String
         get() = "deep_resonance"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/EasyVillagersConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/EasyVillagersConfiguration.kt
@@ -11,7 +11,7 @@ object EasyVillagersConfiguration : IntegrationConfiguration {
     private var enableAutoTradeConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableAutoTrader: Boolean
-        get() = enableAutoTradeConfig?.get() ?: true
+        get() = enableAutoTradeConfig.getOrDefault(true)
 
     override val name: String
         get() = "easy_villagers"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/EmbersConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/EmbersConfiguration.kt
@@ -13,7 +13,7 @@ object EmbersConfiguration : IntegrationConfiguration {
     private var enableEmberStorageConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableEmberStorage: Boolean
-        get() = enableEmberStorageConfig?.get() != false
+        get() = enableEmberStorageConfig.getOrDefault(true)
 
     override fun addToConfig(builder: ForgeConfigSpec.Builder) {
         enableEmberStorageConfig = builder.comment("Enables ember storage integration")

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/FluxNetworksConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/FluxNetworksConfiguration.kt
@@ -11,7 +11,7 @@ object FluxNetworksConfiguration : IntegrationConfiguration {
     private var enableFluxControllerConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableFluxController: Boolean
-        get() = enableFluxControllerConfig?.get() != false
+        get() = enableFluxControllerConfig.getOrDefault(true)
 
     override val name: String
         get() = "flux_networks"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/IntegratedDynamicsConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/IntegratedDynamicsConfiguration.kt
@@ -15,13 +15,13 @@ object IntegratedDynamicsConfiguration : IntegrationConfiguration {
     private var maxJSONSizeConfig: ForgeConfigSpec.IntValue? = null
 
     val enableVariableStore: Boolean
-        get() = enableVariableStoreConfig?.get() ?: true
+        get() = enableVariableStoreConfig.getOrDefault(true)
 
     val enableComputerAspect: Boolean
-        get() = enableComputerAspectConfig?.get() ?: true
+        get() = enableComputerAspectConfig.getOrDefault(true)
 
     val maxJsonSize: Int
-        get() = maxJSONSizeConfig?.get() ?: DEFAULT_MAX_JSON_SIZE
+        get() = maxJSONSizeConfig.getOrDefault(DEFAULT_MAX_JSON_SIZE)
 
     override val name: String
         get() = "integrateddynamics"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ModernIndustrializationConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ModernIndustrializationConfiguration.kt
@@ -12,9 +12,9 @@ object ModernIndustrializationConfiguration : IntegrationConfiguration {
     private var enableCraftingMachineConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableEnergyStorage: Boolean
-        get() = enableEnergyStorageConfig?.get() ?: true
+        get() = enableEnergyStorageConfig.getOrDefault(true)
     val enableCraftingMachine: Boolean
-        get() = enableCraftingMachineConfig?.get() ?: true
+        get() = enableCraftingMachineConfig.getOrDefault(true)
 
     override val name: String
         get() = "modern_industrialization"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/NaturesCompassConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/NaturesCompassConfiguration.kt
@@ -12,10 +12,10 @@ object NaturesCompassConfiguration : IntegrationConfiguration {
     private var enablePocketUpgradeConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableNaturesCompassTurtleUpgrade: Boolean
-        get() = enableTurtleUpgradeConfig?.get() ?: true
+        get() = enableTurtleUpgradeConfig.getOrDefault(true)
 
     val enableNaturesCompassPocketUpgrade: Boolean
-        get() = enablePocketUpgradeConfig?.get() ?: true
+        get() = enablePocketUpgradeConfig.getOrDefault(true)
 
     override val name: String
         get() = "naturescompass"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/OccultismConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/OccultismConfiguration.kt
@@ -12,10 +12,10 @@ object OccultismConfiguration : IntegrationConfiguration {
     private var enableOccultismGoldenBowlConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableOccultismStorage: Boolean
-        get() = enableOccultismStorageConfig?.get() ?: true
+        get() = enableOccultismStorageConfig.getOrDefault(true)
 
     val enableOccultismGoldenBowl: Boolean
-        get() = enableOccultismGoldenBowlConfig?.get() ?: true
+        get() = enableOccultismGoldenBowlConfig.getOrDefault(true)
 
     override val name: String
         get() = "occultism"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/PowahConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/PowahConfiguration.kt
@@ -15,19 +15,19 @@ object PowahConfiguration : IntegrationConfiguration {
     private var enableRedstoneControlConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableEnergy: Boolean
-        get() = enableEnergyConfig?.get() ?: true
+        get() = enableEnergyConfig.getOrDefault(true)
 
     val enableGenerator: Boolean
-        get() = enableGeneraotrConfig?.get() ?: true
+        get() = enableGeneraotrConfig.getOrDefault(true)
 
     val enableEnderCell: Boolean
-        get() = enableEnergyCellConfig?.get() ?: true
+        get() = enableEnergyCellConfig.getOrDefault(true)
 
     val enableReactor: Boolean
-        get() = enableReactorConfig?.get() ?: true
+        get() = enableReactorConfig.getOrDefault(true)
 
     val enableRedstoneControl: Boolean
-        get() = enableRedstoneControlConfig?.get() ?: true
+        get() = enableRedstoneControlConfig.getOrDefault(true)
 
     override val name: String
         get() = "powah"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ProjectEConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/ProjectEConfiguration.kt
@@ -12,10 +12,10 @@ object ProjectEConfiguration : IntegrationConfiguration {
     private var enablePocketUpgradeConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableTransmutationTabletTurtleUpgrade: Boolean
-        get() = enableTurtleUpgradeConfig?.get() ?: true
+        get() = enableTurtleUpgradeConfig.getOrDefault(true)
 
     val enableTransmutationTabletPocketUpgrade: Boolean
-        get() = enablePocketUpgradeConfig?.get() ?: true
+        get() = enablePocketUpgradeConfig.getOrDefault(true)
 
     override val name: String
         get() = "projecte"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/TheurgyConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/TheurgyConfiguration.kt
@@ -14,7 +14,7 @@ object TheurgyConfiguration : IntegrationConfiguration {
     private var enableMercuryFluxStorageConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableMercuryFluxStorage: Boolean
-        get() = enableMercuryFluxStorageConfig?.get() != false
+        get() = enableMercuryFluxStorageConfig.getOrDefault(true)
 
     override fun addToConfig(builder: ForgeConfigSpec.Builder) {
         enableMercuryFluxStorageConfig = builder.comment("Enables mercury flux storage integration")

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/TomsStorageConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/TomsStorageConfiguration.kt
@@ -11,7 +11,7 @@ object TomsStorageConfiguration : IntegrationConfiguration {
     private var enableTomsStorageConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableTomsStorage: Boolean
-        get() = enableTomsStorageConfig?.get() ?: true
+        get() = enableTomsStorageConfig.getOrDefault(true)
 
     override val name: String
         get() = "toms_storage"

--- a/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/UniversalShopsConfiguration.kt
+++ b/projects/core/src/main/kotlin/site/siredvin/peripheralworks/common/configuration/integration/UniversalShopsConfiguration.kt
@@ -11,7 +11,7 @@ object UniversalShopsConfiguration : IntegrationConfiguration {
     private var enableShopsConfig: ForgeConfigSpec.BooleanValue? = null
 
     val enableShops: Boolean
-        get() = enableShopsConfig?.get() ?: true
+        get() = enableShopsConfig.getOrDefault(true)
 
     override val name: String
         get() = "universal_shops"


### PR DESCRIPTION
## Summary
- guard all integration configuration reads until the shared Forge config spec is loaded
- preserve each integration's existing default during early registry events, then use configured values after loading
- fix the reproduced Integrated Dynamics `NewRegistryEvent` crash and the same failure class for every discovered integration configuration

## Verification
- `./gradlew :core:compileKotlin :fabric:compileKotlin :forge:compileKotlin --no-daemon` (exit 0, 23s)
- full Forge integration startup passed Integrated Dynamics, Nature's Compass, Ars Nouveau, and ProjectE registry initialization; the run later stopped on an unrelated Mana and Artifice `ConcurrentModificationException`
- `xvfb-run -a ./gradlew gameTest --no-daemon -PminimalTestEnvironment` (exit 0, 86s; Forge 44/44, Fabric 44/44)
- `./gradlew build --no-daemon` (exit 0, 48s)
