### PR TITLE
fix: address post-1.8 AE2 review findings

### DIFF
--- a/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2CraftingJobs.kt
+++ b/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2CraftingJobs.kt
@@ -1,10 +1,16 @@
 package site.siredvin.peripheralworks.integrations.ae2
 
+import appeng.api.networking.IGridNode
 import appeng.api.networking.crafting.CalculationStrategy
 import appeng.api.networking.crafting.ICraftingLink
+import appeng.api.networking.crafting.ICraftingPlan
 import appeng.api.networking.crafting.ICraftingService
+import appeng.api.networking.crafting.ICraftingSimulationRequester
 import appeng.api.networking.security.IActionSource
 import appeng.blockentity.grid.AENetworkBlockEntity
+import appeng.me.cluster.implementations.CraftingCPUCluster
+import dan200.computercraft.api.lua.ILuaContext
+import dan200.computercraft.api.lua.LuaException
 import dan200.computercraft.api.lua.LuaFunction
 import dan200.computercraft.api.lua.MethodResult
 import net.minecraft.core.BlockPos
@@ -23,31 +29,24 @@ import java.util.Collections
 import java.util.Locale
 import java.util.Optional
 import java.util.WeakHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 object AE2CraftingJobs {
-    private data class Job(val service: WeakReference<ICraftingService>, val target: Map<String, Any>, val amount: Long)
+    private data class Job(val service: WeakReference<ICraftingService>, val target: Map<String, Any>, val amount: Long, val cpu: WeakReference<CraftingCPUCluster>?)
 
     // ponytail: job counts are tiny; scan weak keys until UUID lookup is proven necessary.
     private val jobs = Collections.synchronizedMap(WeakHashMap<ICraftingLink, Job>())
 
-    fun schedule(
-        level: Level,
+    fun submit(
         service: ICraftingService,
         source: IActionSource,
-        mode: String,
-        id: String,
-        amount: Optional<Long>,
+        plan: ICraftingPlan,
+        publicAmount: Long,
         targetCPU: Optional<String>,
     ): MethodResult {
-        val publicAmount = amount.orElse(if (mode == "item") 1 else 1000)
-        if (publicAmount <= 0) return MethodResult.of(null, "Amount must be positive")
-        val key = buildKey(mode, id)
-        val realAmount = try {
-            if (mode == "fluid") Math.multiplyExact(publicAmount, PlatformToolkit.get().fluidCompactDivider.toLong()) else publicAmount
-        } catch (_: ArithmeticException) {
-            return MethodResult.of(null, "Amount is too large")
-        }
-        val plan = service.beginCraftingCalculation(level, { source }, key, realAmount, CalculationStrategy.REPORT_MISSING_ITEMS).get()
         if (!plan.missingItems().isEmpty) return MethodResult.of(false, "Missing items", keyCounterToLua(plan.missingItems()))
         val cpu = if (targetCPU.isPresent) {
             service.cpus.firstOrNull { it.name?.string == targetCPU.get() }
@@ -55,13 +54,18 @@ object AE2CraftingJobs {
         } else {
             null
         }
+        val standaloneCPUs = service.cpus.filterIsInstance<CraftingCPUCluster>()
+        val previousLinks = standaloneCPUs.mapNotNull { it.craftingLogic.lastLink }.toSet()
         val submitted = service.submitJob(plan, null, cpu, false, source)
         if (!submitted.successful()) {
             return MethodResult.of(null, "Cannot submit crafting job: ${submitted.errorCode()?.name?.lowercase(Locale.ROOT) ?: "unknown error"}")
         }
-        val link = submitted.link() ?: return MethodResult.of(null, "AE2 did not return a crafting job")
+        // Standalone jobs return their output to network storage and keep the link on the CPU.
+        val link = submitted.link() ?: standaloneCPUs.mapNotNull { it.craftingLogic.lastLink }.firstOrNull { it !in previousLinks }
+            ?: return MethodResult.of(null, "AE2 did not return a crafting job")
         val jobID = link.craftingID.toString()
-        jobs[link] = Job(WeakReference(service), stackToMap(plan.finalOutput()), publicAmount)
+        val submittedCPU = standaloneCPUs.firstOrNull { it.craftingLogic.lastLink === link }
+        jobs[link] = Job(WeakReference(service), stackToMap(plan.finalOutput()), publicAmount, submittedCPU?.let { WeakReference(it) })
         return MethodResult.of(true, jobID)
     }
 
@@ -75,9 +79,11 @@ object AE2CraftingJobs {
     }
 
     fun cancel(service: ICraftingService, jobID: String): MethodResult {
-        val (link) = find(service, jobID) ?: return missing(jobID)
-        if (link.isCanceled) return MethodResult.of(false, "Crafting job '$jobID' is already canceled")
-        if (link.isDone) return MethodResult.of(false, "Crafting job '$jobID' is already done")
+        val (link, job) = find(service, jobID) ?: return missing(jobID)
+        when (state(link, job)) {
+            "canceled" -> return MethodResult.of(false, "Crafting job '$jobID' is already canceled")
+            "done" -> return MethodResult.of(false, "Crafting job '$jobID' is already done")
+        }
         link.cancel()
         return MethodResult.of(true)
     }
@@ -87,13 +93,21 @@ object AE2CraftingJobs {
             ?.let { it.key to it.value }
     }
 
+    private fun state(link: ICraftingLink, job: Job): String {
+        if (link.isCanceled) return "canceled"
+        if (link.isDone) return "done"
+        job.cpu?.let {
+            val cpu = it.get() ?: return "canceled"
+            if (cpu.isDestroyed) return "canceled"
+            // Standalone links have no requester nexus, so AE2's markDone does not update the link itself.
+            if (cpu.craftingLogic.lastLink !== link) return "done"
+        }
+        return "running"
+    }
+
     private fun toMap(link: ICraftingLink, job: Job): Map<String, Any> = mapOf(
         "id" to link.craftingID.toString(),
-        "state" to when {
-            link.isCanceled -> "canceled"
-            link.isDone -> "done"
-            else -> "running"
-        },
+        "state" to state(link, job),
         "target" to job.target,
         "amount" to job.amount,
     )
@@ -106,12 +120,82 @@ class AE2CraftingJobsPlugin private constructor(
     private val withActionSource: (((IActionSource) -> MethodResult) -> MethodResult),
     private val unavailableMessage: String,
 ) : IPeripheralPlugin {
-    private data class Context(val level: Level, val service: ICraftingService)
+    private data class Context(val level: Level, val service: ICraftingService, val node: IGridNode)
 
     @LuaFunction(mainThread = false)
-    fun scheduleCrafting(mode: String, id: String, amount: Optional<Long>, targetCPU: Optional<String>): MethodResult {
-        val context = resolve() ?: return unavailable()
-        return withActionSource { source -> AE2CraftingJobs.schedule(context.level, context.service, source, mode, id, amount, targetCPU) }
+    fun scheduleCrafting(luaContext: ILuaContext, mode: String, id: String, amount: Optional<Long>, targetCPU: Optional<String>): MethodResult {
+        val publicAmount = amount.orElse(if (mode == "item") 1 else 1000)
+        if (publicAmount <= 0) return MethodResult.of(null, "Amount must be positive")
+        var initialContext: Context? = null
+        val calculation = AtomicReference<Future<ICraftingPlan>>()
+        val abandoned = AtomicBoolean(false)
+
+        fun poll(): MethodResult {
+            var pending = false
+            val task = luaContext.executeMainThreadTask {
+                try {
+                    if (abandoned.get()) return@executeMainThreadTask emptyArray()
+                    val context = resolve()
+                    if (context == null || (initialContext != null && context != initialContext)) {
+                        calculation.get()?.cancel(true)
+                        return@executeMainThreadTask unavailable().result
+                    }
+                    if (calculation.get() == null) {
+                        val key = buildKey(mode, id)
+                        val realAmount = try {
+                            if (mode == "fluid") Math.multiplyExact(publicAmount, PlatformToolkit.get().fluidCompactDivider.toLong()) else publicAmount
+                        } catch (_: ArithmeticException) {
+                            return@executeMainThreadTask MethodResult.of(null, "Amount is too large").result
+                        }
+                        val started = withActionSource { source ->
+                            val requester = object : ICraftingSimulationRequester {
+                                override fun getActionSource(): IActionSource = source
+
+                                // Player-only action sources have no machine node; AE2 still needs a node to discover patterns.
+                                override fun getGridNode(): IGridNode = context.node
+                            }
+                            calculation.set(context.service.beginCraftingCalculation(context.level, requester, key, realAmount, CalculationStrategy.REPORT_MISSING_ITEMS))
+                            MethodResult.of()
+                        }
+                        if (calculation.get() == null) return@executeMainThreadTask started.result
+                        initialContext = context
+                    }
+                    val future = calculation.get()!!
+                    if (abandoned.get()) return@executeMainThreadTask emptyArray()
+                    // Yield through CC's bounded task queue; never wait on an unfinished calculation on either thread.
+                    if (!future.isDone) {
+                        pending = true
+                        return@executeMainThreadTask emptyArray()
+                    }
+                    val plan = try {
+                        future.get()
+                    } catch (error: ExecutionException) {
+                        throw LuaException("Cannot calculate crafting job: ${error.cause?.message ?: error.message}")
+                    }
+                    // Resolve access and create the action source again after the asynchronous calculation.
+                    withActionSource { source -> AE2CraftingJobs.submit(context.service, source, plan, publicAmount, targetCPU) }.result
+                } catch (error: Exception) {
+                    calculation.get()?.cancel(true)
+                    throw error
+                } finally {
+                    if (abandoned.get()) calculation.get()?.cancel(true)
+                }
+            }
+            fun resume(result: MethodResult): MethodResult {
+                val callback = result.callback ?: return if (pending) poll() else result
+                return MethodResult.yield(result.result) { arguments ->
+                    try {
+                        resume(callback.resume(arguments))
+                    } catch (error: Exception) {
+                        abandoned.set(true)
+                        calculation.get()?.cancel(true)
+                        throw error
+                    }
+                }
+            }
+            return resume(task)
+        }
+        return poll()
     }
 
     @LuaFunction(mainThread = true)
@@ -132,15 +216,25 @@ class AE2CraftingJobsPlugin private constructor(
     private fun unavailable(): MethodResult = MethodResult.of(null, unavailableMessage)
 
     companion object {
+        @Suppress("DEPRECATION")
         fun forMachine(level: Level, entity: AENetworkBlockEntity) = AE2CraftingJobsPlugin(
-            resolve = { entity.mainNode.grid?.craftingService?.let { Context(level, it) } },
+            resolve = {
+                if (entity.isRemoved || !level.hasChunkAt(entity.blockPos) || level.getBlockEntity(entity.blockPos) !== entity) {
+                    null
+                } else {
+                    entity.mainNode.node?.let { Context(level, it.grid.craftingService, it) }
+                }
+            },
             withActionSource = { callback -> callback(IActionSource.ofMachine(entity)) },
             unavailableMessage = "AE2 network is not connected",
         )
 
         fun forWirelessComputer(owner: BasePeripheralOwner) = AE2CraftingJobsPlugin(
             resolve = {
-                owner.level?.let { level -> Context(level, resolveWirelessSession(owner).craftingService) }
+                owner.level?.let { level ->
+                    val session = resolveWirelessSession(owner)
+                    Context(level, session.craftingService, session.accessPointNode)
+                }
             },
             withActionSource = { callback -> owner.withPlayer({ callback(IActionSource.ofPlayer(it.fakePlayer)) }, skipInventory = true) },
             unavailableMessage = "Linked AE2 network is unavailable",

--- a/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2StorageSubscriptions.kt
+++ b/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2StorageSubscriptions.kt
@@ -18,6 +18,7 @@ import net.minecraft.core.BlockPos
 import net.minecraft.core.Direction
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.NbtIo
 import net.minecraft.nbt.Tag
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.world.level.Level
@@ -30,7 +31,10 @@ import site.siredvin.tweakium.modules.peripheral.api.IPeripheralPlugin
 import site.siredvin.tweakium.modules.peripheral.representation.LuaRepresentation
 import site.siredvin.tweakium.modules.peripheral.representation.RepresentationMode
 import site.siredvin.tweakium.modules.plugins.PeripheralPluginUtils
+import java.io.DataOutputStream
+import java.io.OutputStream
 import java.util.TreeMap
+import java.util.concurrent.CopyOnWriteArraySet
 import java.util.function.Predicate
 
 private const val SUBSCRIPTIONS_TAG = "ae2StorageSubscriptions"
@@ -41,6 +45,8 @@ private const val VALUE_TAG = "value"
 private const val ENTRIES_TAG = "entries"
 private const val KEY_TAG = "key"
 private const val MAX_FILTER_DEPTH = 16
+private const val MAX_FILTER_BYTES = 65536
+private const val MAX_NBT_STRING_BYTES = 65535
 
 private const val STRING_VALUE: Byte = 1
 private const val NUMBER_VALUE: Byte = 2
@@ -89,7 +95,9 @@ class AE2StorageSubscriptionTracker(
 ) {
     private val subscriptions = TreeMap<String, RuntimeSubscription>()
     private val amounts = mutableMapOf<AEKey, Long>()
-    private val eventSinks = mutableSetOf<(String, Map<String, Any>, Long, Long) -> Unit>()
+
+    // Attach/detach may run on computer threads; dispatch uses a stable snapshot.
+    private val eventSinks = CopyOnWriteArraySet<(String, Map<String, Any>, Long, Long) -> Unit>()
     private var baselined = false
 
     var onDefinitionsChanged: (() -> Unit)? = null
@@ -99,7 +107,7 @@ class AE2StorageSubscriptionTracker(
         get() = subscriptions.isNotEmpty() && eventSinks.isNotEmpty()
 
     fun subscribe(name: String, typeName: String, filter: Any?) {
-        if (name.isBlank()) throw LuaException("Subscription name must not be empty")
+        validateName(name)
         if (name !in subscriptions && subscriptions.size >= maxSubscriptions) {
             throw LuaException("Peripheral cannot have more than $maxSubscriptions AE2 storage subscriptions")
         }
@@ -108,8 +116,13 @@ class AE2StorageSubscriptionTracker(
         val definition = AE2StorageSubscriptionDefinition(name, type, normalizedFilter)
         val runtime = compile(definition)
         val wasObserving = shouldObserve
-        subscriptions[name] = runtime
-        onDefinitionsChanged?.invoke()
+        val previous = subscriptions.put(name, runtime)
+        try {
+            onDefinitionsChanged?.invoke()
+        } catch (error: Exception) {
+            if (previous == null) subscriptions.remove(name) else subscriptions[name] = previous
+            throw error
+        }
         if (wasObserving != shouldObserve) onActivityChanged?.invoke()
     }
 
@@ -126,15 +139,12 @@ class AE2StorageSubscriptionTracker(
     fun getSubscriptions(): List<Map<String, Any>> = subscriptions.values.map { it.definition.toLua() }
 
     fun addEventSink(sink: (String, Map<String, Any>, Long, Long) -> Unit) {
-        val wasObserving = shouldObserve
-        eventSinks.add(sink)
-        if (wasObserving != shouldObserve) onActivityChanged?.invoke()
+        // Do not read the server-owned subscription map from an attachment thread.
+        if (eventSinks.add(sink)) onActivityChanged?.invoke()
     }
 
     fun removeEventSink(sink: (String, Map<String, Any>, Long, Long) -> Unit) {
-        val wasObserving = shouldObserve
-        eventSinks.remove(sink)
-        if (wasObserving != shouldObserve) onActivityChanged?.invoke()
+        if (eventSinks.remove(sink)) onActivityChanged?.invoke()
     }
 
     fun baseline(counter: KeyCounter) {
@@ -190,7 +200,7 @@ class AE2StorageSubscriptionTracker(
             try {
                 val entry = raw as CompoundTag
                 val name = entry.getString("name")
-                if (name.isBlank()) throw IllegalArgumentException("Empty subscription name")
+                validateName(name)
                 val type = AE2StorageSubscriptionType.parse(entry.getString("subscriptionType"))
                 val filter = if (entry.contains(FILTER_TAG, Tag.TAG_COMPOUND.toInt())) {
                     decodeValue(entry.getCompound(FILTER_TAG), 0, intArrayOf(0), maxItemFilterSize)
@@ -211,7 +221,16 @@ class AE2StorageSubscriptionTracker(
     private fun normalizeFilter(type: AE2StorageSubscriptionType, filter: Any?): Any? = when (type) {
         AE2StorageSubscriptionType.ITEM -> {
             if (filter != null && filter !is String && filter !is Map<*, *>) throw LuaException("Item query should be string or table")
-            normalizeValue(filter, 0, intArrayOf(0), maxItemFilterSize).also { PeripheralPluginUtils.itemQueryToPredicate(it) }
+            normalizeValue(filter, 0, intArrayOf(0), maxItemFilterSize).also {
+                PeripheralPluginUtils.itemQueryToPredicate(it)
+                if (it != null) {
+                    val encoded = encodeValue(it, 0, intArrayOf(0), maxItemFilterSize)
+                    DataOutputStream(OutputStream.nullOutputStream()).use { output ->
+                        NbtIo.write(encoded, output)
+                        if (output.size() > MAX_FILTER_BYTES) throw LuaException("Subscription filter exceeds $MAX_FILTER_BYTES encoded bytes")
+                    }
+                }
+            }
         }
         AE2StorageSubscriptionType.FLUID -> {
             if (filter == null) {
@@ -405,11 +424,31 @@ internal class AE2WirelessStorageObserver(private val tracker: AE2StorageSubscri
     }
 }
 
+private fun validateName(name: String) {
+    if (name.isBlank()) throw LuaException("Subscription name must not be empty")
+    checkStringBytes(name, MAX_NBT_STRING_BYTES)
+}
+
+private fun checkStringBytes(value: String, limit: Int) {
+    if (value.length > limit) throw LuaException("Subscription string exceeds $limit NBT bytes")
+    var bytes = 0
+    for (char in value) {
+        // NBT uses modified UTF-8: NUL takes two bytes and surrogates take three each.
+        bytes += when (char.code) {
+            in 1..127 -> 1
+            in 0..2047 -> 2
+            else -> 3
+        }
+        if (bytes > limit) throw LuaException("Subscription string exceeds $limit NBT bytes")
+    }
+}
+
 private fun normalizeValue(value: Any?, depth: Int, count: IntArray, maxValues: Int): Any? {
     if (value == null) return null
     if (depth > MAX_FILTER_DEPTH || ++count[0] > maxValues) throw LuaException("Subscription item filter exceeds the configured size limit of $maxValues values")
     return when (value) {
-        is String, is Boolean -> value
+        is String -> value.also { checkStringBytes(it, MAX_NBT_STRING_BYTES) }
+        is Boolean -> value
         is Number -> value.toDouble().also {
             if (!it.isFinite()) throw LuaException("Subscription filter contains an invalid number")
         }
@@ -422,6 +461,7 @@ private fun normalizeValue(value: Any?, depth: Int, count: IntArray, maxValues: 
                     }
                     else -> throw LuaException("Subscription filter table keys must be strings or numbers")
                 }
+                normalizeValue(normalizedKey, depth + 1, count, maxValues)
                 put(normalizedKey, normalizeValue(nested, depth + 1, count, maxValues) ?: throw LuaException("Subscription filter table values must not be nil"))
             }
         }

--- a/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2WirelessTerminal.kt
+++ b/projects/core/src/ae2Integration/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2WirelessTerminal.kt
@@ -179,8 +179,8 @@ private class AE2WirelessTerminalPlugin(
         val transferLimit = min(PeripheralWorksConfig.itemStorageTransferLimit, limit.orElse(Int.MAX_VALUE))
         if (transferLimit < 0) throw LuaException("Limit must be non-negative")
         val inventorySize = owner.storage!!.size
+        if (slot.isPresent && slot.get() !in 1..inventorySize) throw LuaException("Slot must be between 1 and $inventorySize")
         val storageSlot = slot.map { it - 1 }.orElse(-1)
-        if (storageSlot !in -1 until inventorySize) throw LuaException("Slot must be between 1 and $inventorySize")
         return predicate to (transferLimit to storageSlot)
     }
 

--- a/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2CraftingJobsGameTests.kt
+++ b/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2CraftingJobsGameTests.kt
@@ -1,0 +1,192 @@
+package site.siredvin.peripheralworks.testmod
+
+import appeng.api.networking.IGridNode
+import appeng.api.networking.crafting.ICraftingLink
+import appeng.api.networking.crafting.ICraftingPlan
+import appeng.api.networking.crafting.ICraftingService
+import appeng.api.networking.crafting.ICraftingSimulationRequester
+import appeng.api.networking.crafting.ICraftingSubmitResult
+import appeng.api.networking.security.IActionSource
+import appeng.api.stacks.AEItemKey
+import appeng.api.stacks.GenericStack
+import appeng.api.stacks.KeyCounter
+import com.google.common.collect.ImmutableSet
+import dan200.computercraft.api.lua.ILuaContext
+import dan200.computercraft.api.lua.LuaException
+import dan200.computercraft.api.lua.LuaTask
+import dan200.computercraft.api.lua.MethodResult
+import net.minecraft.gametest.framework.GameTest
+import net.minecraft.gametest.framework.GameTestHelper
+import net.minecraft.world.item.Items
+import net.minecraft.world.level.Level
+import site.siredvin.peripheralworks.integrations.ae2.AE2CraftingJobsPlugin
+import site.siredvin.testiarium.api.TestGroup
+import java.lang.reflect.Proxy
+import java.util.Optional
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.FutureTask
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+@TestGroup("ae2")
+class AE2CraftingJobsGameTests {
+    @GameTest(template = "empty")
+    fun craftingThreadHandoffsAndRevalidation(helper: GameTestHelper) {
+        val success = CraftingRequestHarness(helper)
+        var result = success.start()
+        check(success.starts == 0) { "Scheduling touched the world before its server task" }
+        result = success.advance(result)
+        check(success.starts == 1 && success.submissions == 0 && result.callback != null) { "Pending calculation did not yield" }
+        success.calculation.complete(success.plan)
+        result = success.advance(result)
+        check(result.result!!.contentEquals(arrayOf<Any>(true, success.jobID.toString())))
+        check(success.submissions == 1 && success.sourceResolutions == 2) { "Submission did not reacquire its action source" }
+
+        val lost = CraftingRequestHarness(helper)
+        val waiting = lost.advance(lost.start())
+        lost.available = false
+        val rejected = lost.advance(waiting)
+        check(rejected.result!![0] == null && lost.calculation.isCancelled && lost.submissions == 0) { "Lost access still submitted a crafting job" }
+
+        val relinked = CraftingRequestHarness(helper)
+        val relinkWaiting = relinked.advance(relinked.start())
+        relinked.node = craftingProxy { _, _ -> error("Unexpected node call") }
+        relinked.calculation.complete(relinked.plan)
+        check(relinked.advance(relinkWaiting).result!![0] == null && relinked.submissions == 0) { "Relinked request submitted the old plan" }
+
+        val failed = CraftingRequestHarness(helper)
+        val failureWaiting = failed.advance(failed.start())
+        failed.calculation.completeExceptionally(IllegalStateException("test calculation failed"))
+        val error = runCatching { failed.advance(failureWaiting) }.exceptionOrNull()
+        check(error is LuaException && error.message!!.contains("test calculation failed")) { "Calculation failure was not reported to Lua: $error" }
+        check(failed.submissions == 0)
+        helper.succeed()
+    }
+
+    @GameTest(template = "empty")
+    fun terminatedCraftingCannotStartOrSubmit(helper: GameTestHelper) {
+        for (startCalculation in listOf(false, true)) {
+            val harness = CraftingRequestHarness(helper)
+            var result = harness.start()
+            if (startCalculation) result = harness.advance(result)
+            check(runCatching { onCraftingComputerThread { result.callback!!.resume(arrayOf("terminate")) } }.exceptionOrNull() is LuaException)
+            harness.runTask()
+            check(harness.submissions == 0)
+            if (startCalculation) check(harness.calculation.isCancelled) else check(harness.starts == 0)
+        }
+        helper.succeed()
+    }
+}
+
+// Keep timing deterministic without introducing a test-only scheduler into production.
+// The other wireless GameTest exercises real AE2 calculation/submission from Lua.
+private class CraftingRequestHarness(private val helper: GameTestHelper) : ILuaContext {
+    val calculation = CompletableFuture<ICraftingPlan>()
+    val jobID: UUID = UUID.randomUUID()
+    var starts = 0
+    var submissions = 0
+    var sourceResolutions = 0
+    var available = true
+    var node: IGridNode = craftingProxy { _, _ -> error("Unexpected node call") }
+    private val tasks = LinkedBlockingQueue<Pair<Long, LuaTask>>()
+    private val taskIds = AtomicLong()
+    private val player = helper.makeMockPlayer()
+    private val link: ICraftingLink = craftingProxy { name, _ ->
+        when (name) {
+            "getCraftingID" -> jobID
+            else -> error("Unexpected link call: $name")
+        }
+    }
+    val plan: ICraftingPlan = craftingProxy { name, _ ->
+        when (name) {
+            "missingItems" -> KeyCounter()
+            "finalOutput" -> GenericStack(AEItemKey.of(Items.STONE), 1)
+            else -> error("Unexpected plan call: $name")
+        }
+    }
+    private val service: ICraftingService = craftingProxy { name, args ->
+        check(helper.level.server.isSameThread) { "$name ran off the server thread" }
+        when (name) {
+            "getCpus" -> ImmutableSet.of<appeng.api.networking.crafting.ICraftingCPU>()
+            "beginCraftingCalculation" -> {
+                starts++
+                val requester = args[1] as ICraftingSimulationRequester
+                check(requester.gridNode === node && requester.actionSource?.player()?.orElse(null) === player)
+                calculation
+            }
+            "submitJob" -> {
+                submissions++
+                check(args[0] === plan && (args[4] as IActionSource).player().orElse(null) === player)
+                craftingProxy<ICraftingSubmitResult> { method, _ ->
+                    when (method) {
+                        "successful" -> true
+                        "link" -> link
+                        else -> error("Unexpected submission result call: $method")
+                    }
+                }
+            }
+            else -> error("Unexpected service call: $name")
+        }
+    }
+    private val plugin: AE2CraftingJobsPlugin
+
+    init {
+        val contextClass = AE2CraftingJobsPlugin::class.java.declaredClasses.single { it.simpleName == "Context" }
+        val contextConstructor = contextClass.getDeclaredConstructor(Level::class.java, ICraftingService::class.java, IGridNode::class.java).apply { isAccessible = true }
+        val resolve: () -> Any? = {
+            check(helper.level.server.isSameThread) { "Access resolution ran off the server thread" }
+            if (available) contextConstructor.newInstance(helper.level, service, node) else null
+        }
+        val withSource: ((IActionSource) -> MethodResult) -> MethodResult = { callback ->
+            check(helper.level.server.isSameThread) { "Player setup ran off the server thread" }
+            sourceResolutions++
+            callback(IActionSource.ofPlayer(player))
+        }
+        val constructor = AE2CraftingJobsPlugin::class.java.declaredConstructors.single { it.parameterCount == 3 }.apply { isAccessible = true }
+        plugin = constructor.newInstance(resolve, withSource, "Access lost") as AE2CraftingJobsPlugin
+    }
+
+    override fun issueMainThreadTask(task: LuaTask): Long = taskIds.incrementAndGet().also { tasks.add(it to task) }
+
+    fun start(): MethodResult = onCraftingComputerThread { plugin.scheduleCrafting(this, "item", "minecraft:stone", Optional.of(1L), Optional.empty()) }
+
+    fun runTask(): Array<Any?> {
+        val (id, task) = tasks.remove()
+        return try {
+            task.execute()
+            arrayOf("task_complete", id, true)
+        } catch (error: Exception) {
+            arrayOf("task_complete", id, false, error.message)
+        }
+    }
+
+    fun advance(result: MethodResult): MethodResult {
+        val event = runTask()
+        return onCraftingComputerThread { result.callback!!.resume(event) }
+    }
+}
+
+private fun onCraftingComputerThread(action: () -> MethodResult): MethodResult {
+    val task = FutureTask(action)
+    val thread = Thread(task, "UPW crafting test computer")
+    thread.start()
+    return try {
+        task.get(1, TimeUnit.SECONDS)
+    } catch (error: java.util.concurrent.ExecutionException) {
+        throw error.cause!!
+    } finally {
+        thread.interrupt()
+        thread.join(1000)
+    }
+}
+
+private inline fun <reified T> craftingProxy(noinline invoke: (String, Array<out Any?>) -> Any?): T = Proxy.newProxyInstance(T::class.java.classLoader, arrayOf(T::class.java)) { proxy, method, args ->
+    when (method.name) {
+        "hashCode" -> System.identityHashCode(proxy)
+        "equals" -> proxy === args?.get(0)
+        "toString" -> "CraftingTest${T::class.java.simpleName}"
+        else -> invoke(method.name, args ?: emptyArray())
+    }
+} as T

--- a/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2GameTests.kt
+++ b/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2GameTests.kt
@@ -9,6 +9,7 @@ import appeng.api.networking.security.IActionSource
 import appeng.api.orientation.BlockOrientation
 import appeng.api.parts.PartHelper
 import appeng.api.stacks.AEItemKey
+import appeng.api.stacks.KeyCounter
 import appeng.api.storage.StorageCells
 import appeng.api.util.AECableType
 import appeng.api.util.AEColor
@@ -26,6 +27,7 @@ import net.minecraft.gametest.framework.GameTest
 import net.minecraft.gametest.framework.GameTestHelper
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.NbtIo
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.material.Fluids
@@ -42,6 +44,11 @@ import site.siredvin.peripheralworks.integrations.ae2.MENetworkPeripheralBlockEn
 import site.siredvin.peripheralworks.integrations.ae2.Registration
 import site.siredvin.testiarium.api.TestGroup
 import site.siredvin.testiarium.cct.thenLua
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.util.concurrent.atomic.AtomicReference
 import site.siredvin.peripheralworks.common.setup.Blocks as ModBlocks
 import site.siredvin.peripheralworks.common.setup.Items as ModItems
 
@@ -145,6 +152,100 @@ class AE2GameTests {
         val restored = AE2StorageSubscriptionTracker(maxSubscriptions = 2)
         check(restored.load(persisted))
         check(restored.getSubscriptions().map { it["name"] } == listOf("a", "b"))
+        helper.succeed()
+    }
+
+    @GameTest(template = "empty")
+    fun storageSubscriptionWireLimitsAndAtomicity(helper: GameTestHelper) {
+        fun roundTrip(tracker: AE2StorageSubscriptionTracker, maxValues: Int = 1024) {
+            val bytes = ByteArrayOutputStream()
+            DataOutputStream(bytes).use { NbtIo.write(tracker.save(), it) }
+            val restored = AE2StorageSubscriptionTracker(maxItemFilterSize = maxValues)
+            check(!restored.load(DataInputStream(ByteArrayInputStream(bytes.toByteArray())).use { NbtIo.read(it)!! }))
+            check(restored.getSubscriptions() == tracker.getSubscriptions()) { "Definitions did not survive the NBT wire format" }
+        }
+        val limited = AE2StorageSubscriptionTracker(maxItemFilterSize = 3)
+        limited.subscribe("existing", "item", mapOf("displayName" to "Original"))
+        var persisted = limited.save()
+        limited.onDefinitionsChanged = { persisted = limited.save() }
+        val original = limited.getSubscriptions()
+        val originalTag = persisted.copy()
+        check(runCatching { limited.subscribe("existing", "item", mapOf("displayName" to "Stone", "tag" to "minecraft:logs")) }.exceptionOrNull() is dan200.computercraft.api.lua.LuaException)
+        check(limited.getSubscriptions() == original && persisted == originalTag)
+        roundTrip(limited, 3)
+        limited.onDefinitionsChanged = { error("Persistence unavailable") }
+        check(runCatching { limited.subscribe("existing", "item", "minecraft:stone") }.isFailure)
+        check(limited.getSubscriptions() == original)
+        check(runCatching { limited.subscribe("new", "fluid", null) }.isFailure)
+        check(limited.getSubscriptions() == original)
+
+        val tracker = AE2StorageSubscriptionTracker(maxItemFilterSize = 1024)
+        tracker.subscribe("tags", "item", mapOf("tag" to mapOf("in" to (1..509).associateWith { "example:tag$it" })))
+        roundTrip(tracker)
+        val before = tracker.getSubscriptions()
+        check(runCatching { tracker.subscribe("tags", "item", mapOf("tag" to mapOf("in" to (1..510).associateWith { "example:tag$it" }))) }.exceptionOrNull() is dan200.computercraft.api.lua.LuaException)
+        check(tracker.getSubscriptions() == before)
+        roundTrip(tracker)
+        helper.succeed()
+    }
+
+    @GameTest(template = "empty")
+    fun storageSubscriptionStringBounds(helper: GameTestHelper) {
+        val tracker = AE2StorageSubscriptionTracker()
+        listOf("a".repeat(65535), "\u0000".repeat(32767) + "a", "界".repeat(21845)).forEach { tracker.subscribe(it, "fluid", null) }
+        tracker.subscribe("large-filter", "item", mapOf("displayName" to "a".repeat(65000)))
+        val before = tracker.getSubscriptions()
+        val bytes = ByteArrayOutputStream()
+        DataOutputStream(bytes).use { NbtIo.write(tracker.save(), it) }
+        val restored = AE2StorageSubscriptionTracker()
+        check(!restored.load(DataInputStream(ByteArrayInputStream(bytes.toByteArray())).use { NbtIo.read(it)!! }))
+        check(restored.getSubscriptions() == before)
+        listOf("a".repeat(65536), "\u0000".repeat(32768), "界".repeat(21846), "🌳".repeat(10923)).forEach { name ->
+            check(runCatching { tracker.subscribe(name, "fluid", null) }.exceptionOrNull() is dan200.computercraft.api.lua.LuaException)
+        }
+        listOf(
+            mapOf("displayName" to "a".repeat(65536)),
+            mapOf("displayName" to "界".repeat(21846)),
+            mapOf("displayName" to "\u0000".repeat(32768)),
+            mapOf("a".repeat(65536) to "value"),
+            mapOf("displayName" to "a".repeat(33000), "tag" to "b".repeat(33000)),
+        ).forEach { filter ->
+            check(runCatching { tracker.subscribe("large-filter", "item", filter) }.exceptionOrNull() is dan200.computercraft.api.lua.LuaException)
+        }
+        check(tracker.getSubscriptions() == before) { "Rejected strings changed definitions" }
+        helper.succeed()
+    }
+
+    @GameTest(template = "empty")
+    fun storageSubscriptionConcurrentAttachment(helper: GameTestHelper) {
+        val tracker = AE2StorageSubscriptionTracker()
+        tracker.subscribe("stone", "item", "minecraft:stone")
+        val key = AEItemKey.of(Items.STONE)
+        tracker.baseline(KeyCounter())
+        var oldSinkEvents = 0
+        var newSinkEvents = 0
+        val oldSink: (String, Map<String, Any>, Long, Long) -> Unit = { _, _, _, _ -> oldSinkEvents++ }
+        val newSink: (String, Map<String, Any>, Long, Long) -> Unit = { _, _, _, _ -> newSinkEvents++ }
+        val failure = AtomicReference<Throwable>()
+        tracker.addEventSink { _, _, _, _ ->
+            val attachment = Thread {
+                try {
+                    tracker.removeEventSink(oldSink)
+                    tracker.addEventSink(newSink)
+                } catch (error: Throwable) {
+                    failure.set(error)
+                }
+            }
+            attachment.start()
+            attachment.join(1000)
+            check(!attachment.isAlive) { "Attach/detach blocked on event dispatch" }
+            failure.get()?.let { throw it }
+        }
+        tracker.addEventSink(oldSink)
+        tracker.onStackChange(key, 1)
+        check(oldSinkEvents == 1 && newSinkEvents == 0) { "In-flight dispatch did not retain its snapshot" }
+        tracker.onStackChange(key, 2)
+        check(oldSinkEvents == 1 && newSinkEvents == 1) { "Subsequent dispatch did not see changed attachments" }
         helper.succeed()
     }
 

--- a/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2WirelessTerminalGameTests.kt
+++ b/projects/core/src/ae2Test/kotlin/site/siredvin/peripheralworks/testmod/AE2WirelessTerminalGameTests.kt
@@ -1,9 +1,12 @@
 package site.siredvin.peripheralworks.testmod
 
 import appeng.api.config.Actionable
+import appeng.api.crafting.PatternDetailsHelper
 import appeng.api.networking.IGrid
 import appeng.api.networking.security.IActionSource
 import appeng.api.stacks.AEItemKey
+import appeng.api.stacks.GenericStack
+import appeng.blockentity.crafting.PatternProviderBlockEntity
 import appeng.blockentity.networking.WirelessAccessPointBlockEntity
 import appeng.blockentity.storage.ChestBlockEntity
 import appeng.core.definitions.AEBlocks
@@ -90,6 +93,14 @@ class AE2WirelessTerminalGameTests {
         helper.level.setBlockAndUpdate(energyPos, AEBlocks.CREATIVE_ENERGY_CELL.block().defaultBlockState())
         helper.level.setBlockAndUpdate(chestPos, AEBlocks.CHEST.block().defaultBlockState())
         (helper.level.getBlockEntity(chestPos) as ChestBlockEntity).setCell(AEItems.ITEM_CELL_1K.stack())
+        val providerPos = energyPos.west()
+        helper.level.setBlockAndUpdate(energyPos.above(), AEBlocks.CRAFTING_STORAGE_1K.block().defaultBlockState())
+        helper.level.setBlockAndUpdate(providerPos, AEBlocks.PATTERN_PROVIDER.block().defaultBlockState())
+        helper.level.setBlockAndUpdate(providerPos.west(), net.minecraft.world.level.block.Blocks.CHEST.defaultBlockState())
+        (helper.level.getBlockEntity(providerPos) as PatternProviderBlockEntity).logic.patternInv.setItemDirect(
+            0,
+            PatternDetailsHelper.encodeProcessingPattern(arrayOf(GenericStack(AEItemKey.of(Items.DIRT), 1)), arrayOf(GenericStack(AEItemKey.of(Items.DIAMOND), 1))),
+        )
 
         val terminalItem = AEItems.WIRELESS_CRAFTING_TERMINAL.asItem()
         val terminal = AEItems.WIRELESS_CRAFTING_TERMINAL.stack().apply {
@@ -154,8 +165,8 @@ class AE2WirelessTerminalGameTests {
             .thenExecuteFailFast {
                 state().check("initial")
                 check(turtle.access.fuelLevel == 7) { "Expected three fuel-consuming calls, got ${turtle.access.fuelLevel}" }
-                check(turtle.contents[0].count == 5 && turtle.contents[0].`is`(Items.STONE))
-                check(turtle.contents[15].count == 5 && turtle.contents[15].`is`(Items.GOLD_INGOT))
+                check(turtle.contents[0].count == 5 && turtle.contents[0].`is`(Items.STONE)) { "Invalid slot calls changed turtle stone inventory" }
+                check(turtle.contents[15].count == 5 && turtle.contents[15].`is`(Items.GOLD_INGOT)) { "Invalid slot calls changed turtle gold inventory" }
                 check(grid.size() == gridSizeWithoutObserver + 1) { "Wireless storage observer was not attached" }
                 check(grid.pathingService.usedChannels == usedChannelsWithoutObserver) { "Wireless storage observer consumed an AE2 channel" }
                 turtle.access.fuelLevel = 0
@@ -202,8 +213,30 @@ class AE2WirelessTerminalGameTests {
                 helper.level.setBlockAndUpdate(energyPos, AEBlocks.CREATIVE_ENERGY_CELL.block().defaultBlockState())
             }
             .thenWaitUntil { await("reactivated") }
+            .thenWaitUntil {
+                grid = (helper.level.getBlockEntity(accessPointPos) as WirelessAccessPointBlockEntity).grid!!
+                if (!grid.craftingService.isCraftable(AEItemKey.of(Items.DIAMOND))) throw GameTestAssertException("Processing pattern is not yet available after network rejoin")
+            }
             .thenExecuteFailFast {
                 state().check("reactivated")
+                check(grid.storageService.inventory.insert(AEItemKey.of(Items.DIRT), 4, Actionable.MODULATE, IActionSource.empty()) == 4L) { "Failed to seed crafting ingredients after network rejoin" }
+            }
+            .thenWaitUntil { await("crafting-canceled") }
+            .thenWaitUntil { if (grid.craftingService.cpus.any { it.isBusy }) throw GameTestAssertException("Crafting CPU is still busy after cancellation") }
+            .thenExecuteFailFast {
+                state().check("crafting-canceled")
+                check(grid.storageService.inventory.insert(AEItemKey.of(Items.IRON_NUGGET), 1, Actionable.MODULATE, IActionSource.empty()) == 1L)
+            }
+            .thenWaitUntil { await("crafting-running") }
+            .thenWaitUntil { if (!grid.craftingService.isRequesting(AEItemKey.of(Items.DIAMOND))) throw GameTestAssertException("Crafting CPU has not requested output") }
+            .thenExecuteFailFast {
+                state().check("crafting-running")
+                // Simulate the external processing machine returning its output through AE2 storage.
+                check(grid.storageService.inventory.insert(AEItemKey.of(Items.DIAMOND), 1, Actionable.MODULATE, IActionSource.empty()) == 1L)
+            }
+            .thenWaitUntil { await("crafting-complete") }
+            .thenExecuteFailFast {
+                state().check("crafting-complete")
                 val data = turtle.access.getUpgradeNBTData(TurtleSide.LEFT)
                 val stored = ItemStack.of(data.getCompound("terminal"))
                 WirelessTerminalItem.LINKABLE_HANDLER.link(stored, GlobalPos.of(helper.level.dimension(), UNLOADED_POS))

--- a/projects/fabric/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/FabricPeripheralWorksTestMod.kt
+++ b/projects/fabric/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/FabricPeripheralWorksTestMod.kt
@@ -19,6 +19,7 @@ object FabricPeripheralWorksTestMod : ModInitializer {
         Testiarium.register(PeripheralWorksGameTests::class.java)
         if (FabricLoader.getInstance().isModLoaded("ae2")) {
             Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2GameTests"))
+            Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2CraftingJobsGameTests"))
             Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2ConfigurableObjectsGameTests"))
             Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2WirelessTerminalGameTests"))
             Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2PatternPedestalGameTests"))

--- a/projects/forge/build.gradle.kts
+++ b/projects/forge/build.gradle.kts
@@ -12,6 +12,8 @@ val modVersion: String by extra
 val minecraftVersion: String by extra
 val modBaseName: String by extra
 val minimalTestEnvironment = providers.gradleProperty("minimalTestEnvironment").isPresent
+val testWithoutAE2 = providers.gradleProperty("testWithoutAE2").isPresent
+require(!testWithoutAE2 || minimalTestEnvironment) { "testWithoutAE2 requires minimalTestEnvironment" }
 
 tasks.named<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>("compileKotlin") {
     source(project(":core").fileTree("src/ae2Integration/kotlin"))
@@ -86,7 +88,11 @@ dependencies {
     compileOnly(fg.deobf("net.createmod.ponder:Ponder-Forge-1.20.1:1.0.51"))
 
     if (minimalTestEnvironment) {
-        implementation(fg.deobf(libs.ae2.forge.get()))
+        if (testWithoutAE2) {
+            compileOnly(fg.deobf(libs.ae2.forge.get()))
+        } else {
+            implementation(fg.deobf(libs.ae2.forge.get()))
+        }
     } else {
         runtimeOnly(fg.deobf(libs.jade.forge.get()))
         libs.bundles.externalMods.forge.integrations.full.get().map { compileOnly(fg.deobf(it)) }

--- a/projects/forge/src/generated/resources/data/peripheralworks/recipes/ae2_pattern_pedestal.json
+++ b/projects/forge/src/generated/resources/data/peripheralworks/recipes/ae2_pattern_pedestal.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:crafting_shaped",
-  "forge:conditions": [
+  "conditions": [
     {
       "type": "forge:mod_loaded",
       "modid": "ae2"

--- a/projects/forge/src/generated/resources/data/peripheralworks/recipes/me_network_peripheral.json
+++ b/projects/forge/src/generated/resources/data/peripheralworks/recipes/me_network_peripheral.json
@@ -1,6 +1,6 @@
 {
   "type": "minecraft:crafting_shaped",
-  "forge:conditions": [
+  "conditions": [
     {
       "type": "forge:mod_loaded",
       "modid": "ae2"

--- a/projects/forge/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2RecipeConditions.kt
+++ b/projects/forge/src/main/kotlin/site/siredvin/peripheralworks/integrations/ae2/AE2RecipeConditions.kt
@@ -11,7 +11,7 @@ object AE2RecipeConditions {
             override fun serializeRecipeData(json: JsonObject) {
                 recipe.serializeRecipeData(json)
                 json.add(
-                    "forge:conditions",
+                    "conditions",
                     JsonArray().apply {
                         add(
                             JsonObject().apply {

--- a/projects/forge/src/testMod/java/site/siredvin/peripheralworks/testmod/ForgePeripheralWorksTestMod.java
+++ b/projects/forge/src/testMod/java/site/siredvin/peripheralworks/testmod/ForgePeripheralWorksTestMod.java
@@ -25,9 +25,11 @@ public final class ForgePeripheralWorksTestMod {
             CctFixtureCommands.INSTANCE.importFiles(event.getServer());
         });
         Testiarium.register(PeripheralWorksGameTests.class);
+        Testiarium.register(ForgeRecipeConditionsGameTests.class);
         if (ModList.get().isLoaded("ae2")) {
             try {
                 Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2GameTests"));
+                Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2CraftingJobsGameTests"));
                 Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2ConfigurableObjectsGameTests"));
                 Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2WirelessTerminalGameTests"));
                 Testiarium.register(Class.forName("site.siredvin.peripheralworks.testmod.AE2PatternPedestalGameTests"));

--- a/projects/forge/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/ForgeRecipeConditionsGameTests.kt
+++ b/projects/forge/src/testMod/kotlin/site/siredvin/peripheralworks/testmod/ForgeRecipeConditionsGameTests.kt
@@ -1,0 +1,28 @@
+package site.siredvin.peripheralworks.testmod
+
+import com.google.gson.JsonParser
+import net.minecraft.gametest.framework.GameTest
+import net.minecraft.gametest.framework.GameTestHelper
+import net.minecraft.resources.ResourceLocation
+import net.minecraftforge.common.crafting.CraftingHelper
+import net.minecraftforge.common.crafting.conditions.ICondition
+import net.minecraftforge.fml.ModList
+import site.siredvin.testiarium.api.TestGroup
+
+@TestGroup("peripheralworks")
+class ForgeRecipeConditionsGameTests {
+    @Suppress("DEPRECATION")
+    @GameTest(template = "empty")
+    fun optionalAE2Recipes(helper: GameTestHelper) {
+        val installed = ModList.get().isLoaded("ae2")
+        listOf("ae2_pattern_pedestal", "me_network_peripheral").forEach { name ->
+            val id = ResourceLocation("peripheralworks", name)
+            val resource = helper.level.server.resourceManager.getResource(ResourceLocation("peripheralworks", "recipes/$name.json")).orElseThrow()
+            val json = resource.openAsReader().use { JsonParser.parseReader(it).asJsonObject }
+            check(json.has("conditions") && !json.has("forge:conditions")) { "$id must use Forge's recipe condition field" }
+            check(CraftingHelper.processConditions(json, "conditions", ICondition.IContext.EMPTY) == installed) { "$id was not gated by AE2 presence" }
+            check(helper.level.recipeManager.byKey(id).isPresent == installed) { "$id had incorrect recipe-manager presence" }
+        }
+        helper.succeed()
+    }
+}

--- a/projects/typed-peripheral-unlimitedperipheralworks/integrations/ae2.ts
+++ b/projects/typed-peripheral-unlimitedperipheralworks/integrations/ae2.ts
@@ -43,6 +43,9 @@ export type AE2StorageSubscriptionResource =
 
 /** @noSelf **/
 export interface AE2StorageSubscriptionAPI {
+    /** Names are limited to 65535 modified-UTF-8 bytes. Item filters must fit both
+     * the configured value limit (including table keys) and 65536 encoded NBT bytes.
+     * Rejected registrations/replacements leave the existing definition unchanged. */
     subscribe(name: string, type: "item", filter?: ItemQuery): void;
     subscribe(name: string, type: "fluid", filter?: string): void;
     unsubscribe(name: string): boolean;
@@ -50,12 +53,14 @@ export interface AE2StorageSubscriptionAPI {
 }
 
 /** @noSelf **/
-export interface AE2NetworkAccessAPI
-    extends IPeripheral,
-        AE2StorageSubscriptionAPI {
+export interface AE2CraftingAPI {
     getCraftingJob(jobId: string): Fallible<AE2CraftingJob>;
     getCraftingJobs(): AE2CraftingJob[];
     cancelCrafting(jobId: string): Fallible<boolean>;
+    /** Yields while AE2 calculates without blocking the server tick. Access is rechecked
+     * before submission; losing the link/range or changing networks rejects the request.
+     * Standalone jobs return their output to network storage. Job IDs are process-local
+     * and only retained while their native AE2 links remain reachable. */
     scheduleCrafting(
         mode: "item" | "fluid",
         id: string,
@@ -72,7 +77,10 @@ export const ae2NetworkAccessProvider =
     new IPeripheralProvider<AE2NetworkAccessAPI>("ae2_network_access");
 
 /** @noSelf **/
-export interface AE2NetworkAPI extends AE2NetworkAccessAPI {
+export interface AE2NetworkAccessAPI extends IPeripheral, AE2CraftingAPI, AE2StorageSubscriptionAPI {}
+
+/** @noSelf **/
+export interface AE2NetworkAPI extends IPeripheral, AE2CraftingAPI {
     getAverageEnergyDemand(): number;
     getAverageEnergyIncome(): number;
     getChannelEnergyDemand(): number;

--- a/projects/typescript-tests/src/ae2_interface.ts
+++ b/projects/typescript-tests/src/ae2_interface.ts
@@ -14,6 +14,9 @@ const fluid = (name: string) => ({ type: "fluid" as const, name });
 
 const target = peripheral.wrap("front") as AE2InterfacePeripheral;
 check(target, "Fixture interface did not become available");
+// @ts-expect-error Legacy interfaces deliberately have no subscription capability.
+check(target.subscribe === undefined, "Legacy interface exposed subscriptions");
+check(target.getCraftingJobs().length === 0, "Disconnected interface returned crafting jobs");
 check(target.getDeviceType() === "interface", `Expected interface, got ${target.getDeviceType()}`);
 target.setStock(1, { ...item("minecraft:iron_ingot"), count: 32 });
 check(target.getStock(1)?.target?.count === 32, "interface item stock did not apply");

--- a/projects/typescript-tests/src/ae2_pattern_provider.ts
+++ b/projects/typescript-tests/src/ae2_pattern_provider.ts
@@ -14,6 +14,9 @@ check(itemInventory, "Fixture inventory did not become available");
 
 const target = peripheral.wrap("front") as AE2PatternProviderPeripheral;
 check(target, "Fixture pattern provider did not become available");
+// @ts-expect-error Legacy pattern providers deliberately have no subscription capability.
+check(target.subscribe === undefined, "Legacy pattern provider exposed subscriptions");
+check(target.getCraftingJobs().length === 0, "Disconnected pattern provider returned crafting jobs");
 check(target.getDeviceType() === "pattern_provider", `Expected pattern_provider, got ${target.getDeviceType()}`);
 target.setPriority(9);
 target.setBlocking(true);

--- a/projects/typescript-tests/src/ae2_wireless_terminal.ts
+++ b/projects/typescript-tests/src/ae2_wireless_terminal.ts
@@ -26,10 +26,8 @@ check(missingJob === null && typeof missingJobError === "string" && missingJobEr
 const [missingCancel, missingCancelError] = networkAccess.cancelCrafting("missing");
 check(missingCancel === null && typeof missingCancelError === "string" && missingCancelError.includes("not found"), "Missing crafting job cancellation was not reported");
 networkAccess.getCraftingJobs();
-const typecheckCraftingRequest = (): void => {
-    const [scheduled, jobId] = networkAccess.scheduleCrafting("item", "minecraft:stone", 1);
-    if (scheduled) networkAccess.getCraftingJob(jobId);
-};
+const [invalidCraft, invalidCraftError] = networkAccess.scheduleCrafting("item", "minecraft:stone", 0);
+check(invalidCraft === null && invalidCraftError.includes("positive"), "Invalid crafting amount was accepted");
 const detailed = terminal.items();
 terminal.items(true);
 const filtered = terminal.items(false, { name: "minecraft:stone" });
@@ -44,6 +42,11 @@ check(terminal.pushItem(16, 3) === 3, "Gold was not pushed from slot 16");
 check(terminal.getFuelLevel() === initialFuel - 3, "Transfers did not consume one fuel each");
 const fuelAfterTransfers = terminal.getFuelLevel();
 check(!pcall(() => terminal.pushItem(17))[0], "Invalid slot was accepted");
+const beforeInvalidStone = terminal.items(false, { name: "minecraft:stone" })[1]?.count;
+check(!pcall(() => terminal.pushItem(0, 1))[0], "Source slot zero was accepted");
+check(!pcall(() => terminal.pullItem("minecraft:stone", 1, 0))[0], "Destination slot zero was accepted");
+check(terminal.items(false, { name: "minecraft:stone" })[1]?.count === beforeInvalidStone &&
+    terminal.items(false, { name: "minecraft:gold_ingot" })[1]?.count === 3, "Invalid slots changed network inventory");
 check(terminal.getFuelLevel() === fuelAfterTransfers, "Invalid slot consumed fuel");
 terminal.items();
 check(terminal.getFuelLevel() === fuelAfterTransfers, "Item listing consumed fuel");
@@ -91,6 +94,23 @@ while (!failure.includes("outside wireless range")) {
 test.ok("inactive");
 while (!pcall(() => terminal.items())[0]) sleep(0.05);
 test.ok("reactivated");
+while (!terminal.items(false, { name: "minecraft:dirt" })[1]) sleep(0.05);
+const [scheduledCancel, cancelId, missingInputs] = networkAccess.scheduleCrafting("item", "minecraft:diamond", 1);
+check(scheduledCancel === true, `Crafting submission failed: ${cancelId}; missing=${textutils.serialize(missingInputs)}; storage=${textutils.serialize(terminal.items())}`);
+const [runningCancel] = networkAccess.getCraftingJob(cancelId);
+check(runningCancel?.state === "running" && runningCancel.amount === 1, "Submitted crafting job was not tracked");
+const [canceled] = networkAccess.cancelCrafting(cancelId);
+check(canceled === true && networkAccess.getCraftingJob(cancelId)[0]?.state === "canceled", "Crafting job was not canceled");
+test.ok("crafting-canceled");
+// A persistent marker cannot be dropped while test.ok is awaiting its task_complete event.
+while (!terminal.items(false, { name: "minecraft:iron_nugget" })[1]) sleep(0.05);
+const [scheduledComplete, completeId] = networkAccess.scheduleCrafting("item", "minecraft:diamond", 1);
+check(scheduledComplete === true, `Second crafting submission failed: ${completeId}`);
+test.ok("crafting-running");
+while (networkAccess.getCraftingJob(completeId)[0]?.state !== "done") sleep(0.05);
+const [cancelDone] = networkAccess.cancelCrafting(completeId);
+check(cancelDone === false, "Completed crafting job was canceled");
+test.ok("crafting-complete");
 failure = "";
 while (!failure.includes("unavailable")) {
     const [ok, error] = pcall(() => terminal.items());


### PR DESCRIPTION
## Summary

Addresses all six findings from the review of `v1.20.1-1.8.0..7ae1dd7`, plus the inherited crafting-threading issue. Targets `1.20`; no release/version bump.

- Align subscription complexity validation with NBT encoding, counting table keys as well as values. Validate the encoded candidate before mutation and roll back live replacements when persistence fails.
- Validate names and filter strings against NBT's 65,535-byte modified-UTF limit and cap encoded item-filter payloads at 65,536 bytes. Preserve the entire valid NBT name range, including non-ASCII/NUL boundaries.
- Use copy-on-write event-sink snapshots for computer-thread attach/detach; attachment callbacks no longer read the server-owned subscription map.
- Reject explicit wireless inventory slot zero before translating public one-based slots to internal indices. Omitted slots still mean any slot.
- Split common crafting typings from the dedicated/wireless subscription capability. Legacy Interface/Pattern Provider fixtures assert both the compile-time and runtime boundary.
- Correct the Forge recipe condition field to `conditions` and regenerate both AE2 recipes. Add an optional-dependency runtime test and a minimal `-PtestWithoutAE2` verification mode; CC upgrade JSON is unchanged.
- Move crafting access resolution, player/source setup and submission onto CC's main-thread task queue. Yield while calculations are pending, revalidate access before submission, report calculation errors, and cancel abandoned requests.

### Additional crafting defects exposed by executing the previously typecheck-only path

- Wireless simulation requesters must provide an AE2 grid node separately from their player action source, otherwise AE2 does not discover crafting patterns. Player attribution is preserved.
- Successful standalone AE2 submissions keep their link on the selected CPU instead of returning it in the submit result. Track that native link without changing native CPU selection or output routing.
- Standalone links have no requester nexus and do not mark themselves done. Derive completion from the original CPU/link association, while preserving weak references and process-local job lifetime.

## Regression coverage

- Real NBT writer/reader round trips; default and small complexity budgets; failed replacement/persistence atomicity; ASCII, NUL, multibyte and surrogate-pair bounds; total payload bounds.
- Deterministic attach/detach during storage-event dispatch.
- Slot-zero rejection with unchanged network/turtle inventory and fuel.
- Legacy subscription API absence checked by TypeScript and real Lua calls.
- Deterministic computer/server thread handoffs, unfinished calculations, changed/lost access, exceptional calculations and termination before/after calculation start.
- Real wireless Lua scheduling against native AE2: successful submission, cancellation, a second submission, completion after processing output returns, and rejection of cancellation after completion.
- Forge recipe loading with AE2 both installed and absent.

## Verification

All commands use `--no-daemon`, explicit deadlines and full logs redirected to ignored build files.

- `timeout --foreground 5m xvfb-run -a ./gradlew :forge:runData --no-daemon -PminimalTestEnvironment` — exit 0, 23s. Retained only the two intended regenerated recipes; restored unrelated minimal-environment datagen churn.
- `timeout --foreground 10m xvfb-run -a ./gradlew :forge:runGameTestServer --no-daemon -PminimalTestEnvironment -PtestWithoutAE2` — exit 0, 67s; 30/30 tests passed, including the recipe presence/condition assertions. Runtime log confirms AE2 is absent.
- `timeout --foreground 20m xvfb-run -a ./gradlew :typescript-tests:compileTestLua gameTest --continue --no-daemon -PminimalTestEnvironment` — final run exit 0, 125s; Fabric 54/54 and Forge 55/55 passed, no failures or skips.
- `timeout --foreground 10m ./gradlew build --no-daemon` — final normal multi-loader build exit 0, 50s; ran after the minimal tests so distributable artifacts include the normal integration set.
- `git diff --check` — passed.

Client rendering was not changed or re-tested. Crafting job tracking remains intentionally process-local and weak-reference-based; this does not add persistent job history.
